### PR TITLE
Fix: Hide parent dataset dropdown if the current dataset is parent

### DIFF
--- a/metadata-app/src/api/index.js
+++ b/metadata-app/src/api/index.js
@@ -145,7 +145,7 @@ const decodeSupplementalValues = (opts) => {
     } else newOpts.describedByType = opts.data_dictionary_type;
   }
 
-  if (opts.is_parent) {
+  if (opts.is_parent === 'true') {
     newOpts.isParent = 'Yes';
   } else {
     newOpts.isParent = 'No';

--- a/metadata-app/src/components/AdditionalMetadata/defaultValues.js
+++ b/metadata-app/src/components/AdditionalMetadata/defaultValues.js
@@ -12,4 +12,5 @@ export default {
   issued: '',
   systemOfRecordsUSG: '',
   isPartOf: '',
+  isParent: 'No',
 };

--- a/metadata-app/src/components/AdditionalMetadata/index.js
+++ b/metadata-app/src/components/AdditionalMetadata/index.js
@@ -231,24 +231,25 @@ const AdditionalMetadata = (props) => {
           />
         </div>
       </div>
-      <div className="row">
-        <div className="grid-col-12">
-          <span className="usa-label">Select Parent Dataset</span>
-          <Autocomplete
-            disabled={values.isParent === 'Yes'}
-            id="tags-autocomplete-input"
-            tags={values.parent}
-            apiUrl={apiUrl}
-            apiKey={apiKey}
-            fetchOpts={api.fetchParentDatasets}
-            name="parent_dataset_id"
-            titleField="name"
-            placeholder="Start typing to search"
-            errors={errors}
-            helptext={<HelpText>Start typing to see list of matching datasets by title</HelpText>}
-          />
+      {values.isParent === 'No' && (
+        <div className="row">
+          <div className="grid-col-12">
+            <span className="usa-label">Select Parent Dataset</span>
+            <Autocomplete
+              id="tags-autocomplete-input"
+              tags={values.parent}
+              apiUrl={apiUrl}
+              apiKey={apiKey}
+              fetchOpts={api.fetchParentDatasets}
+              name="parent_dataset_id"
+              titleField="name"
+              placeholder="Start typing to search"
+              errors={errors}
+              helptext={<HelpText>Start typing to see list of matching datasets by title</HelpText>}
+            />
+          </div>
         </div>
-      </div>
+      )}
       <div className="row">
         <button type="button" className="usa-button usa-button--line">
           Save as draft


### PR DESCRIPTION
- Hide parent dataset dropdown if the current dataset is parent
- Default should be "No"
- On edit mode pre populate "Is Parent" value

![image](https://user-images.githubusercontent.com/3371013/94245394-3967c500-ff2b-11ea-8e06-40d398a38b6b.png)

