### PR TITLE
CI improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,9 @@ jobs:
       - run:
           name: Prepare latest build files
           command: CI=false yarn build
+      - run:
+          name: Run unit tests
+          command: cd ~/ckanext-dcat_usmetadata/metadata-app/ && yarn test
   test_local_docker:
     working_directory: ~/ckanext-dcat_usmetadata
     machine: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,12 +18,16 @@ jobs:
       - run:
           name: Run unit tests
           command: cd ~/ckanext-dcat_usmetadata/metadata-app/ && yarn test
+      - persist_to_workspace:
+          root: ~/
+          paths:
+            - "ckanext-dcat_usmetadata"
   test_local_docker:
     working_directory: ~/ckanext-dcat_usmetadata
     machine: true
     steps:
-      - checkout
-#      - run: make lint-all
+      - attach_workspace:
+          at: ~/
       - run:
           name: Start CKAN
           command: |

--- a/README.md
+++ b/README.md
@@ -51,28 +51,33 @@ Run `make app-cosmos` to start the cosmos server, which will watch the `metadata
 
 ## Local development and end-to-end testing
 
-Use the [inventory app](https://github.com/GSA/inventory-app) locally for end-to-end testing.
+We use the [inventory app](https://github.com/GSA/inventory-app) locally for development and end-to-end (e2e) testing.
 
-It may be neccessarry to remove cached images when rebuilding the inventory app docker container, in order to ensure that the new usmetadata-app template is included in the build. (From the inventory-app directory) use:
+To build the latest JS code and update assets in the CKAN extension, you can run the following command from the root directory of this project:
+
+```
+$ yarn build
+```
+
+For convenience, we have prepared a single script that you can run to perform end-to-end tests locally. Don't forget to `yarn build` prior to running e2e tests:
+
+```
+$ yarn e2e
+```
+
+Note, it may be necessary to remove cached images when rebuilding the inventory app docker container, in order to ensure that the new usmetadata-app template is included in the build. If you want to make sure that you aren't using cached builds, you can try:
 
 ```
 $ docker-compose build --no-cache --pull ckanext-dcat_usmetadata_app
 ```
 
-Build and move latest builds of JS code:
-
-```
-# make sure to run it from root directory of the project
-$ npm run build
-```
-
-With the dcat_usmetadata extension running in the inventory app, use the following command to run end-to-end tests:
+With the dcat_usmetadata extension running in the inventory app, use the following command to run e2e tests:
 
 ```
 $ npx cypress run
 ```
 
-To run tests interactively use:
+To run e2e tests interactively use:
 
 ```
 $ npx cypress open

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "chance": "^1.1.6"
   },
   "scripts": {
+    "e2e": "yarn dockerize && yarn && npx cypress run",
+    "dockerize": "docker-compose -f docker-compose.yml -f docker-compose.seed.yml up -d",
     "build": "yarn build:metadata-app && yarn move:builds && yarn rename:builds",
     "build:metadata-app": "cd metadata-app && yarn && yarn build && cd ..",
     "move:builds": "rm -r ckanext/dcat_usmetadata/public/**/* && cp -r metadata-app/build/static/* ckanext/dcat_usmetadata/public/",


### PR DESCRIPTION
Includes:

* we now run unit tests in the CI prior to running e2e tests;
* we persist build files between jobs so that when running e2e tests, it uses latest builds no matter if developer has pushed it or not.

Also:

* prepared a script to ease running of e2e tests locally so we now can run `yarn e2e` from the root directory of the project;
* updated the README about it.