### PR TITLE
Run deploy job only on master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,3 +99,5 @@ workflows:
           filters:
             tags:
               only: /[0-9]+(\.[0-9]+)*/
+            branches:
+              only: master


### PR DESCRIPTION
Otherwise, when we have a tagged commit in a branch it triggers deploy once. Then when it's merged to master, it tries to trigger deploy job again.

Example:

https://app.circleci.com/pipelines/github/GSA/ckanext-dcat_usmetadata/479/workflows/9cbe35ef-09da-4b43-b6ea-3270679dd2d3/jobs/1144

As you can see, deploy job failed with the following message:

> HTTPError: 400 Client Error: File already exists. See https://pypi.org/help/#file-name-reuse for more information. for url: https://upload.pypi.org/legacy/