### PR TITLE
PyPI package installation

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
 include README.md
 include LICENSE
 include requirements.txt
-recursive-include ckanext/dcat-usmetadata *.html *.json *.js *.less *.css *.mo
+recursive-include ckanext/dcat_usmetadata *.html *.json *.js *.less *.css *.mo

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # http://packaging.python.org/en/latest/tutorial.html#version
-    version='0.1.5',
+    version='0.1.9',
 
     description='''DCAT USMetadata Form App for CKAN''',
     long_description=long_description,


### PR DESCRIPTION
Fixed path to static files in the `MANIFEST.in` as it was wrongly specified with `-` instead of `_`. Probably, the project structure was different in the beginning so it was leftover since then.