### PR TITLE
Fix/dataset url edit

### DIFF
--- a/cypress/integration/required-metadata.spec.js
+++ b/cypress/integration/required-metadata.spec.js
@@ -47,6 +47,29 @@ describe('Required Metadata Page', () => {
     cy.wait(5000);
     cy.contains('Dataset saved successfully');
   });
+
+  it('Edit dataset URL works', () => {
+    cy.login();
+    cy.visit('/dataset/new-metadata');
+    cy.get('input[name=title]').type('my default title');
+    cy.get('button.dataset_url_edit').click();
+    cy.get('input[name=url]').type('-edited');
+    cy.get('textarea[name=description]').type('description');
+    cy.get('.react-tags input').type('1234{enter}');
+    cy.get('select[name=owner_org]').select('test-123');
+    cy.get('select[name=publisher]').select('Other');
+    cy.get('input[name=publisher_other]').type('Other publisher');
+    cy.get('input[name=subagency]').type('Sub Agency 1');
+    cy.get('input[name=contact_name]').type('Person');
+    cy.get('input[name=contact_email]').type('person@mail.com');
+    cy.get('input[name=unique_id]').type('unique id');
+    cy.get('select[name=public_access_level]').select('public');
+    cy.get('select[name=license]').select('MIT');
+    cy.get('button[type=button]').contains('Save and Continue').click().then(() => {
+      cy.visit('/dataset/my-default-title-edited');
+      cy.contains('my default title');
+    });
+  })
 });
 
 describe('Required Metadata Page errors', () => {

--- a/metadata-app/src/api/index.js
+++ b/metadata-app/src/api/index.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import slugify from 'slugify';
 
 const dataDictTypes = require('../components/AdditionalMetadata/data-dictionary-types');
 const licenses = require('../components/RequiredMetadata/licenses.json');
@@ -213,7 +214,9 @@ const deserializeSupplementalValues = (opts) => {
 
 const createDataset = (opts, apiUrl, apiKey) => {
   const body = serializeSupplementalValues(opts);
-  body.name = opts.url.split('/').pop();
+  body.name = opts.url
+    ? opts.url.split('/').pop()
+    : slugify(opts.title, { lower: true, remove: /[*+~.()'"!:@]/g });
   delete body.url;
   body.modified = new Date();
   body.bureau_code = '015:11';

--- a/metadata-app/src/api/index.js
+++ b/metadata-app/src/api/index.js
@@ -1,5 +1,4 @@
 import axios from 'axios';
-import slugify from 'slugify';
 
 const dataDictTypes = require('../components/AdditionalMetadata/data-dictionary-types');
 const licenses = require('../components/RequiredMetadata/licenses.json');
@@ -214,11 +213,11 @@ const deserializeSupplementalValues = (opts) => {
 
 const createDataset = (opts, apiUrl, apiKey) => {
   const body = serializeSupplementalValues(opts);
-  body.name = slugify(opts.title, { lower: true, remove: /[*+~.()'"!:@]/g });
+  body.name = opts.url.split('/').pop();
+  delete body.url;
   body.modified = new Date();
   body.bureau_code = '015:11';
   body.program_code = '015:001';
-  body.url = opts.url;
   return axios
     .post(`${apiUrl}package_create`, encodeValues(body), {
       headers: {

--- a/metadata-app/src/api/index.test.js
+++ b/metadata-app/src/api/index.test.js
@@ -162,7 +162,6 @@ describe('Test helpers', () => {
           const payload = JSON.parse(request.config.data);
 
           expect(request.config.method).toBe('post');
-          console.log(payload[fieldNameEncoded]);
           expect(payload[fieldNameEncoded]).toBe('Foo');
           request.respondWith({
             status: 200,

--- a/metadata-app/src/mocks/apiMocks.js
+++ b/metadata-app/src/mocks/apiMocks.js
@@ -93,6 +93,7 @@ const datasetOne = {
 
 const requiredMetadata = {
   title: 'Test 123',
+  url: 'http://localhost:5000/dataset/test-123',
   description: 'Description 123',
   publisher: 'Publisher 1 ',
   subagency: 'Sub Agency 2',

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # http://packaging.python.org/en/latest/tutorial.html#version
-    version='0.1.10',
+    version='0.1.11',
 
     description='''DCAT USMetadata Form App for CKAN''',
     long_description=long_description,


### PR DESCRIPTION
When editing an auto-generated URL of a dataset, we're actually editing its name. I.e., in CKAN a dataset URL has the following structure: `ckan/dataset/{name}` and we're showing full URL only for UX.

The bug is that when the URL is edited, it is submitted as `url` property of the package which is treated as `source` by CKAN instead of `name`. To make sure that this fix works, we have added an integration test (see first commit in this PR) which edits the URL and checks if dataset page is available.