### PR TITLE
Fix: Load main css file first before chunk css

### DIFF
--- a/ckanext/dcat_usmetadata/templates/new-metadata.html
+++ b/ckanext/dcat_usmetadata/templates/new-metadata.html
@@ -5,8 +5,8 @@
   data-ownerOrg="{{request.params.get('group')}}"
   data-datasetId="{{request.params.get('datasetId') or ''}}"
 ></div>
-<link rel="stylesheet" href="/css/2.chunk.css" type"text/css">
-<link rel="stylesheet" href="/css/main.chunk.css" type"text/css">
+<link rel="stylesheet" href="/css/main.chunk.css" type"text/css"> <link rel="stylesheet"
+href="/css/2.chunk.css" type"text/css">
 <script src="/js/2.chunk.js"></script>
 <script src="/js/main.chunk.js"></script>
 <script src="/js/runtime-main.js"></script>


### PR DESCRIPTION
Chunk css file should be loaded after main css in order to let the classes override the necessary styles. 