### PR TITLE
Create release version 0.2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # http://packaging.python.org/en/latest/tutorial.html#version
-    version='0.2.6',
+    version='0.2.7',
 
     description='''DCAT USMetadata Form App for CKAN''',
     long_description=long_description,


### PR DESCRIPTION
Create release 0.2.7. This  changes public/static dir for resources to public/assets. This is related to https://github.com/gsa/datagov-ckan-multi/issues/390