### PR TITLE
Feature: List resources on edit mode in Resource Upload section

### DIFF
--- a/cypress/integration/resource-upload.spec.js
+++ b/cypress/integration/resource-upload.spec.js
@@ -99,8 +99,8 @@ describe('Resource Upload page', () => {
     cy.wait(15000);
     cy.resourceUploadWithUrlAndSave(exampleUrl);
     cy.wait(5000);
-    cy.get(':nth-child(8) > .grid-col-12 > :nth-child(1)').contains(expectedMessage1);
-    cy.get(':nth-child(8) > .grid-col-12 > :nth-child(3)').contains(expectedMessage2);
+    cy.contains(expectedMessage1);
+    cy.contains(expectedMessage2);
   });
 
   it('List saved resources and truncates long names', () => {

--- a/cypress/integration/resource-upload.spec.js
+++ b/cypress/integration/resource-upload.spec.js
@@ -103,6 +103,32 @@ describe('Resource Upload page', () => {
     cy.get(':nth-child(8) > .grid-col-12 > :nth-child(3)').contains(expectedMessage2);
   });
 
+  it('List saved resources and truncates long names', () => {
+    const title = 'resource-list-edit-test';
+    const exampleUrl = 'https://example.com/data.csv';
+    const shortResourceName = 'First resource';
+    const longResourceName =
+      'Very oooooooooooooooooooooooooooooooooooooooooooooooooooooooo naaaame';
+    cy.requiredMetadata(title);
+    cy.additionalMetadata();
+    cy.get('button[type=button]').contains('Save and Continue').click();
+    cy.resourceUploadWithUrlAndSave(exampleUrl, shortResourceName);
+    cy.wait(3000);
+    cy.resourceUploadWithUrlAndSave(exampleUrl, longResourceName);
+
+    cy.visit(`/dataset/new-metadata?datasetId=${title}`);
+    cy.contains('Resource Upload').click();
+
+    cy.contains(shortResourceName);
+    cy.get(longResourceName).should('not.exist');
+    // Action buttons
+    cy.contains('Delete');
+    cy.contains('Edit');
+    // Truncated the text, three dots
+    cy.contains(/.../);
+    cy.request('POST', '/api/3/action/dataset_purge', { id: title });
+  });
+
   it('Fails to save resource if URL is invalid', () => {
     const invalidUrl = 'example.com/data.csv';
     cy.requiredMetadata();

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -85,11 +85,11 @@ Cypress.Commands.add('resourceUploadWithUrlAndPublish', (url) => {
   cy.get('button[type=button]').contains('Finish and publish').click();
 });
 
-Cypress.Commands.add('resourceUploadWithUrlAndSave', (url) => {
+Cypress.Commands.add('resourceUploadWithUrlAndSave', (url, name) => {
   const resourceUrl = url || chance.url();
   cy.get('label[for=url]').click();
   cy.get('input[name=resource\\.url]').type(resourceUrl);
-  cy.get('input[name=resource\\.name]').type(chance.word());
+  cy.get('input[name=resource\\.name]').type(name || chance.word());
   cy.get('textarea[name=resource\\.description]').type(chance.sentence({ words: 10 }));
   cy.get('select[name=resource\\.mimetype]').select('DOC -- Word Document');
   cy.get('input[name=resource\\.format]').type(chance.word());

--- a/metadata-app/src/components/MetadataForm/__snapshots__/index.test.js.snap
+++ b/metadata-app/src/components/MetadataForm/__snapshots__/index.test.js.snap
@@ -317,7 +317,7 @@ exports[`renders MetadataForm component 1`] = `
                     <span
                       class="usa-helptext"
                     >
-                      If you do not see the Publisher for your dataset listed, please contact
+                      Start typing to see list of publishers. If you do not see the Publisher for your dataset listed, please contact
                        
                       <a
                         class="usa-link usa-link--external"

--- a/metadata-app/src/components/MetadataForm/index.js
+++ b/metadata-app/src/components/MetadataForm/index.js
@@ -292,6 +292,7 @@ const MetadataForm = (props) => {
         <Formik
           initialValues={{
             resource: JSON.parse(JSON.stringify(ResourceObject)),
+            resources: formValues.resources,
             publish: true,
             savedResources: 0,
             lastSavedResource: null,

--- a/metadata-app/src/components/RequiredMetadata/__snapshots__/index.test.js.snap
+++ b/metadata-app/src/components/RequiredMetadata/__snapshots__/index.test.js.snap
@@ -266,7 +266,7 @@ exports[`Renders RequiredMetadata component 1`] = `
               <span
                 class="usa-helptext"
               >
-                If you do not see the Publisher for your dataset listed, please contact
+                Start typing to see list of publishers. If you do not see the Publisher for your dataset listed, please contact
                  
                 <a
                   class="usa-link usa-link--external"

--- a/metadata-app/src/components/RequiredMetadata/index.js
+++ b/metadata-app/src/components/RequiredMetadata/index.js
@@ -115,7 +115,8 @@ const RequiredMetadata = (props) => {
     ),
     select: (
       <HelpText>
-        If you do not see the Publisher for your dataset listed, please contact{' '}
+        Start typing to see list of publishers. If you do not see the Publisher for your dataset
+        listed, please contact{' '}
         <Link target="_blank" href="mailto:inventory-help@gsa.gov">
           inventory-help@gsa.gov
         </Link>{' '}

--- a/metadata-app/src/components/ResourceUpload/__snapshots__/index.test.js.snap
+++ b/metadata-app/src/components/ResourceUpload/__snapshots__/index.test.js.snap
@@ -32,6 +32,7 @@ exports[`Renders Resource Upload component 1`] = `
           . You can also add a URL or file of information related to the dataset such as a data dictionary.
         </p>
       </section>
+      
       <div
         class="grid-row margin-top-3"
       >
@@ -521,7 +522,6 @@ exports[`Renders Resource Upload component 1`] = `
           </button>
         </div>
       </div>
-      
       
       <div
         class="margin-top-6 clearfix"

--- a/metadata-app/src/components/ResourceUpload/__snapshots__/index.test.js.snap
+++ b/metadata-app/src/components/ResourceUpload/__snapshots__/index.test.js.snap
@@ -523,6 +523,7 @@ exports[`Renders Resource Upload component 1`] = `
         </div>
       </div>
       
+      
       <div
         class="margin-top-6 clearfix"
       >

--- a/metadata-app/src/components/ResourceUpload/index.js
+++ b/metadata-app/src/components/ResourceUpload/index.js
@@ -29,6 +29,7 @@ const ResourceUpload = (props) => {
     handleSteps,
   } = props; // eslint-disable-line
   const resource = values.resource || {};
+  const resources = values.resources || [];
   const { url, name, description, mimetype, format } = resource;
 
   const [linkToDataIsActive, setLinkToDataActive] = useState(false);
@@ -68,6 +69,36 @@ const ResourceUpload = (props) => {
           dictionary.
         </p>
       </section>
+      {values.savedResources > 0 ? (
+        <div className="grid-row margin-top-3">
+          <div className="grid-col-12 text-mint">
+            <i>
+              Resource saved: [{values.lastSavedResource}] ({values.savedResources} resources saved
+              in total).
+            </i>
+            <br />
+            <i>You can edit any saved resource after clicking &quot;Finish and publish&quot;.</i>
+          </div>
+        </div>
+      ) : (
+        ''
+      )}
+      {resources.map((res) => {
+        return (
+          <div key={res.id} className="grid-row margin-top-2">
+            <div className="grid-col-12 bg-base-lightest padding-x-1">
+              <div className="resource-item-name">{res.name}</div>
+              <button type="button" className="usa-button--unstyled resource-action-button">
+                Edit
+              </button>
+              <button type="button" className="usa-button--unstyled resource-action-button">
+                Delete
+              </button>
+            </div>
+          </div>
+        );
+      })}
+
       <div className="grid-row margin-top-3">
         <div className="grid-col-12">
           {/* eslint-disable-next-line */}
@@ -202,21 +233,6 @@ const ResourceUpload = (props) => {
         </div>
       </div>
 
-      {values.savedResources > 0 ? (
-        <div className="grid-row margin-top-3">
-          <div className="grid-col-12 text-mint">
-            <i>
-              Resource saved: [{values.lastSavedResource}] ({values.savedResources} resources saved
-              in total).
-            </i>
-            <br />
-            <i>You can edit any saved resource after clicking &quot;Finish and publish&quot;.</i>
-          </div>
-        </div>
-      ) : (
-        ''
-      )}
-
       {isSubmitting ? (
         <div className="usa-alert usa-alert--info usa-alert--slim usa-alert--no-icon">
           <div className="usa-alert__body">
@@ -292,6 +308,7 @@ ResourceUpload.propTypes = {
   draftSaved: PropTypes.string,
   errors: PropTypes.any, // eslint-disable-line
   values: PropTypes.shape({
+    resources: PropTypes.array, // eslint-disable-line
     resource: PropTypes.shape({
       url: PropTypes.string,
       upload: PropTypes.any, // eslint-disable-line

--- a/metadata-app/src/components/ResourceUpload/index.js
+++ b/metadata-app/src/components/ResourceUpload/index.js
@@ -53,6 +53,8 @@ const ResourceUpload = (props) => {
     setFieldValue('resource.upload', event.currentTarget.files[0]);
   };
 
+  const totalSavedResource = values.savedResources + resources.length;
+
   return (
     <div className="usa-form-custom">
       <section id="section-basic-mega-menu" className="site-component-section">
@@ -69,35 +71,32 @@ const ResourceUpload = (props) => {
           dictionary.
         </p>
       </section>
-      {values.savedResources > 0 ? (
-        <div className="grid-row margin-top-3">
-          <div className="grid-col-12 text-mint">
-            <i>
-              Resource saved: [{values.lastSavedResource}] ({values.savedResources} resources saved
-              in total).
-            </i>
-            <br />
-            <i>You can edit any saved resource after clicking &quot;Finish and publish&quot;.</i>
-          </div>
-        </div>
-      ) : (
+      {!totalSavedResource ? (
         ''
-      )}
-      {resources.map((res) => {
-        return (
-          <div key={res.id} className="grid-row margin-top-2">
-            <div className="grid-col-12 bg-base-lightest padding-x-1">
-              <div className="resource-item-name">{res.name}</div>
-              <button type="button" className="usa-button--unstyled resource-action-button">
-                Edit
-              </button>
-              <button type="button" className="usa-button--unstyled resource-action-button">
-                Delete
-              </button>
+      ) : (
+        <div className="margin-top-10 padding-bottom-8 border-gray-10 border-bottom-2px">
+          <div className="grid-row margin-top-3">
+            <div className="grid-col-12 text-mint">
+              <i>Resource saved: ({totalSavedResource} resources saved in total)</i>
             </div>
           </div>
-        );
-      })}
+          {resources.map((res) => {
+            return (
+              <div key={res.id} className="grid-row margin-top-2">
+                <div className="grid-col-12 bg-base-lightest padding-x-1">
+                  <div className="resource-item-name">{res.name}</div>
+                  <button type="button" className="usa-button--unstyled resource-action-button">
+                    Delete
+                  </button>
+                  <button type="button" className="usa-button--unstyled resource-action-button">
+                    Edit
+                  </button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
 
       <div className="grid-row margin-top-3">
         <div className="grid-col-12">
@@ -232,7 +231,20 @@ const ResourceUpload = (props) => {
           </button>
         </div>
       </div>
-
+      {values.savedResources > 0 ? (
+        <div className="grid-row margin-top-3">
+          <div className="grid-col-12 text-mint">
+            <i>
+              Resource saved: [{values.lastSavedResource}] ({values.savedResources} resources saved
+              in total).
+            </i>
+            <br />
+            <i>You can edit any saved resource after clicking &quot;Finish and publish&quot;.</i>
+          </div>
+        </div>
+      ) : (
+        ''
+      )}
       {isSubmitting ? (
         <div className="usa-alert usa-alert--info usa-alert--slim usa-alert--no-icon">
           <div className="usa-alert__body">

--- a/metadata-app/src/css/custom.css
+++ b/metadata-app/src/css/custom.css
@@ -325,3 +325,20 @@ input[type='file'] {
   margin-top: 31px;
   height: 42px;
 }
+.resource-action-button{
+  float: right;
+  margin-right: 10px !important;
+  margin-left: 30px !important;
+  display: block;
+  font-weight: bold !important;
+  height: 100%;
+  cursor: pointer;
+  text-decoration: none !important;
+}
+.resource-item-name{
+  width: calc(100% - 200px);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  float: left;
+}


### PR DESCRIPTION
Related issue: 
https://app.zenhub.com/workspaces/datagov-multi-tenant-ckan-5cf12b601437ff1e943f0aa2/issues/gsa/datagov-ckan-multi/502

It's not completely done, only the FE part such as:
1. Listing the already existing resources
2. Showing mock Edit and Delete buttons
3. Moving "Save..." message to top
4. Long names are truncated
5. Cypress test is written

Demo:
![image](https://user-images.githubusercontent.com/3371013/102713572-a1d40180-42e2-11eb-907e-06fe27cc40a7.png)
