### PR TITLE
Create dataset as private by default

### DIFF
--- a/metadata-app/src/api/index.js
+++ b/metadata-app/src/api/index.js
@@ -421,7 +421,7 @@ const fetchOrganizationsForUser = async (apiUrl, apiKey) => {
 const fetchParentDatasets = async (query, apiUrl, apiKey) => {
   try {
     // the space belongs here q= solr query string including indexed extras
-    const url = `${apiUrl}package_search?q=${query} extras_is_parent=true`;
+    const url = `${apiUrl}package_search?q=${query} extras_is_parent=true include_private=true`;
     const res = await axios.get(url, {
       headers: {
         'X-CKAN-API-Key': apiKey,

--- a/metadata-app/src/api/index.js
+++ b/metadata-app/src/api/index.js
@@ -298,6 +298,7 @@ const createDataset = (opts, apiUrl, apiKey) => {
   delete body.url;
   body.bureau_code = '015:11';
   body.program_code = '015:001';
+  body.private = true;
   return axios
     .post(`${apiUrl}package_create`, encodeValues(body), {
       headers: {


### PR DESCRIPTION
Related to https://github.com/GSA/datagov-deploy/issues/2314#issuecomment-749095379
If the dataset needs to be made public for resource access, [this internal logic](https://github.com/GSA/USMetadata/blob/master/ckanext/usmetadata/plugin.py#L689-L696) should handle that use case.