### PR TITLE
Feature/save draft

### DIFF
--- a/ckanext/dcat_usmetadata/db_utils.py
+++ b/ckanext/dcat_usmetadata/db_utils.py
@@ -20,9 +20,9 @@ def get_parent_organizations(c):
         for id in userGroupsIds:
             ids.append(id.encode('ascii', 'ignore'))
 
-        # Ugly hack - If user has access to only one organization then SQL query
-        # blows up because IN statement ends up with dangling comma at the end.
-        # Adding dumy id should fix that.
+        # Ugly hack - If user has access to only one organization then SQL
+        # query blows up because IN statement ends up with dangling comma at
+        # the end. Adding dumy id should fix that.
         if(len(ids) == 0):
             ids.append("null")
             ids.append("dummy-id")

--- a/ckanext/dcat_usmetadata/db_utils.py
+++ b/ckanext/dcat_usmetadata/db_utils.py
@@ -1,0 +1,38 @@
+import ckan.model as model
+
+
+def get_parent_organizations(c):
+    items = {}
+
+    if not c.userobj:
+        return items
+
+    if c.userobj.sysadmin:
+        query = "select package_id, title from package_extra , package " \
+                "where package_extra.key = 'is_parent' and package_extra.value = 'true' " \
+                "and package.id = package_extra.package_id and package.state = 'active' "
+    else:
+        userGroupsIds = c.userobj.get_group_ids()
+        ids = []
+
+        for id in userGroupsIds:
+            ids.append(id.encode('ascii', 'ignore'))
+
+        # Ugly hack - If user has access to only one organization then SQL query blows up because IN statement ends up with
+        # dangling comma at the end. Adding dumy id should fix that.
+        if(len(ids) == 0):
+            ids.append("null")
+            ids.append("dummy-id")
+        elif(len(ids) == 1):
+            ids.append("dummy-id")
+        query = "select package_id, title from package_extra , package " \
+                "where package_extra.key = 'is_parent' and package_extra.value = 'true' " \
+                "and package.id = package_extra.package_id and package.state = 'active' " \
+                "and package.owner_org in " + str(tuple(ids))
+
+    connection = model.Session.connection()
+    res = connection.execute(query).fetchall()
+    for result in res:
+        items[result._row[0]] = result._row[1]
+
+    return items

--- a/ckanext/dcat_usmetadata/db_utils.py
+++ b/ckanext/dcat_usmetadata/db_utils.py
@@ -9,8 +9,10 @@ def get_parent_organizations(c):
 
     if c.userobj.sysadmin:
         query = "select package_id, title from package_extra , package " \
-                "where package_extra.key = 'is_parent' and package_extra.value = 'true' " \
-                "and package.id = package_extra.package_id and package.state = 'active' "
+                "where package_extra.key = 'is_parent' " \
+                "and package_extra.value = 'true' " \
+                "and package.id = package_extra.package_id " \
+                "and package.state = 'active' "
     else:
         userGroupsIds = c.userobj.get_group_ids()
         ids = []
@@ -18,16 +20,19 @@ def get_parent_organizations(c):
         for id in userGroupsIds:
             ids.append(id.encode('ascii', 'ignore'))
 
-        # Ugly hack - If user has access to only one organization then SQL query blows up because IN statement ends up with
-        # dangling comma at the end. Adding dumy id should fix that.
+        # Ugly hack - If user has access to only one organization then SQL query
+        # blows up because IN statement ends up with dangling comma at the end.
+        # Adding dumy id should fix that.
         if(len(ids) == 0):
             ids.append("null")
             ids.append("dummy-id")
         elif(len(ids) == 1):
             ids.append("dummy-id")
         query = "select package_id, title from package_extra , package " \
-                "where package_extra.key = 'is_parent' and package_extra.value = 'true' " \
-                "and package.id = package_extra.package_id and package.state = 'active' " \
+                "where package_extra.key = 'is_parent' " \
+                "and package_extra.value = 'true' " \
+                "and package.id = package_extra.package_id " \
+                "and package.state = 'active' " \
                 "and package.owner_org in " + str(tuple(ids))
 
     connection = model.Session.connection()

--- a/ckanext/dcat_usmetadata/plugin.py
+++ b/ckanext/dcat_usmetadata/plugin.py
@@ -1,10 +1,16 @@
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
+import db_utils as utils
+from ckan.common import c
+from logging import getLogger
 
+
+log = getLogger(__name__)
 
 class Dcat_UsmetadataPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IConfigurer)
     plugins.implements(plugins.IRoutes)
+    plugins.implements(plugins.IActions)
 
     # IConfigurer
     def update_config(self, config_):
@@ -28,3 +34,11 @@ class Dcat_UsmetadataPlugin(plugins.SingletonPlugin):
 
     def after_map(self, map):
         return map
+
+    # IActions
+    def get_actions(self):
+        def parent_dataset_options(context, data_dict):
+            return utils.get_parent_organizations(c)
+        return {
+            'parent_dataset_options': parent_dataset_options,
+        }

--- a/ckanext/dcat_usmetadata/plugin.py
+++ b/ckanext/dcat_usmetadata/plugin.py
@@ -7,6 +7,7 @@ from logging import getLogger
 
 log = getLogger(__name__)
 
+
 class Dcat_UsmetadataPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IConfigurer)
     plugins.implements(plugins.IRoutes)

--- a/cypress/integration/additional-metadata.spec.js
+++ b/cypress/integration/additional-metadata.spec.js
@@ -62,6 +62,7 @@ describe('Parent Dataset', () => {
 
     cy.requiredMetadata(title);
     cy.additionalMetadata();
+    cy.get('select[name=isParent]').select('Yes');
     cy.get('button[type=button]').contains('Save and Continue').click();
     cy.resourceUploadWithUrlAndPublish();
 
@@ -69,7 +70,6 @@ describe('Parent Dataset', () => {
     cy.requiredMetadata();
     cy.get('.react-autosuggest__container input').type(title);
     cy.get('.react-autosuggest__suggestion--first').click();
-    cy.additionalMetadata();
     cy.get('.react-autosuggest__container input').should('have.value', title);
   });
 });

--- a/cypress/integration/additional-metadata.spec.js
+++ b/cypress/integration/additional-metadata.spec.js
@@ -73,3 +73,15 @@ describe('Parent Dataset', () => {
     cy.get('.react-autosuggest__container input').should('have.value', title);
   });
 });
+
+describe('Save draft functionality on Additional Metadata page', () => {
+  it('Saves dataset using "Save draft" button', () => {
+    cy.requiredMetadata();
+    cy.get('.usa-button--outline').contains('Save draft').click();
+    cy.contains('Draft saved');
+
+    cy.get('select[name=dataQuality]').select('Yes');
+    cy.get('.usa-button--outline').contains('Save draft').click();
+    cy.contains('Draft saved');
+  });
+});

--- a/cypress/integration/edit-dataset.spec.js
+++ b/cypress/integration/edit-dataset.spec.js
@@ -190,4 +190,8 @@ describe('Editing an existing dataset', () => {
     cy.get('input[name=system_of_records]').invoke('val').should('eq', newMetadata.systemOfRecords);
     cy.get('select[name=isParent]').invoke('val').should('eq', newMetadata.isParent);
   });
+
+  it('Hides "Save draft" button when in edit mode', () => {
+    cy.contains('Save draft').should('not.exist');
+  });
 });

--- a/cypress/integration/resource-upload.spec.js
+++ b/cypress/integration/resource-upload.spec.js
@@ -145,3 +145,23 @@ describe('Resource Upload page', () => {
     );
   });
 });
+
+describe('Save draft functionality on Resource Upload page', () => {
+  it('Saves draft', () => {
+    cy.requiredMetadata();
+    cy.intercept('/api/3/action/package_update').as('packageUpdate');
+    cy.get('button[type=button]').contains('Save and Continue').click();
+    cy.wait('@packageUpdate');
+    cy.contains('Save and add another resource');
+    cy.get('.usa-button--outline').contains('Save draft').click();
+    cy.contains('Draft saved');
+
+    cy.intercept('/api/3/action/resource_create').as('resourceCreate');
+    cy.get('label[for=url]').click();
+    cy.get('input[name=resource\\.url]').type(chance.url());
+    cy.get('input[name=resource\\.name]').type(chance.word());
+    cy.get('.usa-button--outline').contains('Save draft').click();
+    cy.wait('@resourceCreate');
+    cy.contains('Draft saved');
+  });
+});

--- a/metadata-app/src/api/index.js
+++ b/metadata-app/src/api/index.js
@@ -94,6 +94,8 @@ const serializeSupplementalValues = (opts) => {
     const indexOfNotes = newOpts.extras.findIndex((x) => x.key === 'notes');
     if (indexOfNotes > -1) {
       newOpts.extras[indexOfNotes].value = opts.description;
+    } else {
+      newOpts.extras.push({ key: 'notes', value: newOpts.notes });
     }
   }
 
@@ -452,6 +454,7 @@ const createDataset = (opts, apiUrl, apiKey) => {
   body.name = opts.url
     ? opts.url.split('/').pop()
     : slugify(opts.title, { lower: true, remove: /[*+~.()'"!:@]/g });
+  body.notes = body.notes || '';
   delete body.url;
   body.bureau_code = '015:11';
   body.program_code = '015:001';

--- a/metadata-app/src/api/index.js
+++ b/metadata-app/src/api/index.js
@@ -583,16 +583,20 @@ const fetchOrganizationsForUser = async (apiUrl, apiKey) => {
 const fetchParentDatasets = async (query, apiUrl, apiKey) => {
   try {
     // the space belongs here q= solr query string including indexed extras
-    const url = `${apiUrl}package_search?q=${query} extras_is_parent=true`;
-    const res = await axios.get(url, {
-      headers: {
-        'X-CKAN-API-Key': apiKey,
-      },
-    });
-    return (res.data.result.results || []).map(({ id, title }) => {
+    const url = `${apiUrl}parent_dataset_options`;
+    const res = await axios.post(
+      url,
+      {},
+      {
+        headers: {
+          'X-CKAN-API-Key': apiKey,
+        },
+      }
+    );
+    return Object.keys(res.data.result).map((id) => {
       return {
         id,
-        name: title,
+        name: res.data.result[id],
       };
     });
   } catch (e) {

--- a/metadata-app/src/components/AdditionalMetadata/__snapshots__/index.test.js.snap
+++ b/metadata-app/src/components/AdditionalMetadata/__snapshots__/index.test.js.snap
@@ -1260,7 +1260,6 @@ exports[`Renders RequiredMetadata component 1`] = `
       >
         <button
           class="usa-button usa-button--outline float-left"
-          style="display: none;"
           type="button"
         >
           Save draft

--- a/metadata-app/src/components/AdditionalMetadata/__snapshots__/index.test.js.snap
+++ b/metadata-app/src/components/AdditionalMetadata/__snapshots__/index.test.js.snap
@@ -1259,7 +1259,7 @@ exports[`Renders RequiredMetadata component 1`] = `
         class="margin-top-6 clearfix"
       >
         <button
-          class="usa-button usa-button--outline float-left"
+          class="usa-button usa-button--outline"
           type="button"
         >
           Save draft

--- a/metadata-app/src/components/AdditionalMetadata/index.js
+++ b/metadata-app/src/components/AdditionalMetadata/index.js
@@ -272,16 +272,20 @@ const AdditionalMetadata = (props) => {
         </div>
       )}
       <div className="margin-top-6 clearfix">
-        <button
-          className="usa-button usa-button--outline float-left"
-          type="button"
-          onClick={async () => {
-            await setFieldValue('saveDraft', true);
-            submitForm();
-          }}
-        >
-          Save draft
-        </button>
+        {values.publishing_status === 'Published' ? (
+          ''
+        ) : (
+          <button
+            className="usa-button usa-button--outline"
+            type="button"
+            onClick={async () => {
+              await setFieldValue('saveDraft', true);
+              submitForm();
+            }}
+          >
+            Save draft
+          </button>
+        )}
         <div className="float-right">
           <button
             className="usa-button usa-button--outline"
@@ -346,6 +350,7 @@ AdditionalMetadata.propTypes = {
     isPartOf: PropTypes.string,
     isParent: PropTypes.string,
     parentDataset: PropTypes.string,
+    publishing_status: PropTypes.string,
   }),
 };
 

--- a/metadata-app/src/components/AdditionalMetadata/index.js
+++ b/metadata-app/src/components/AdditionalMetadata/index.js
@@ -273,7 +273,6 @@ const AdditionalMetadata = (props) => {
       )}
       <div className="margin-top-6 clearfix">
         <button
-          style={{ display: 'none' }}
           className="usa-button usa-button--outline float-left"
           type="button"
           onClick={async () => {

--- a/metadata-app/src/components/MetadataForm/__snapshots__/index.test.js.snap
+++ b/metadata-app/src/components/MetadataForm/__snapshots__/index.test.js.snap
@@ -878,7 +878,6 @@ exports[`renders MetadataForm component 1`] = `
             >
               <button
                 class="usa-button usa-button--outline"
-                style="display: none;"
                 type="button"
               >
                 Save draft

--- a/metadata-app/src/components/MetadataForm/index.js
+++ b/metadata-app/src/components/MetadataForm/index.js
@@ -361,6 +361,9 @@ const MetadataForm = (props) => {
                     handleError(error);
                     setSubmitting(false);
                   });
+              } else if (values.saveDraft) {
+                setDraftSaved(new Date());
+                setSubmitting(false);
               }
             } else {
               setAlert(

--- a/metadata-app/src/components/MetadataForm/index.js
+++ b/metadata-app/src/components/MetadataForm/index.js
@@ -63,7 +63,8 @@ const MetadataForm = (props) => {
   const [formValues, setFormValues] = useState({
     ...defaultRequiredValues,
     ...defaultAdditionalValues,
-    state: 'draft',
+    publishing_status: 'Draft',
+    private: true,
     saveDraft: false,
   });
 
@@ -315,15 +316,18 @@ const MetadataForm = (props) => {
                   .then((res) => {
                     if (res.status === 200) {
                       if (values.publish) {
-                        // Update dataset state: 'draft' => 'active'
-                        Api.patchDataset(curDatasetId, { state: 'active' }, apiUrl, apiKey).then(
-                          (response) => {
-                            if (response.status === 200) {
-                              // Redirect to dataset page
-                              window.location.replace(datasetPageUrl);
-                            }
+                        // Update dataset state: 'publishing_status' => 'published'
+                        Api.patchDataset(
+                          curDatasetId,
+                          { publishing_status: 'Published' },
+                          apiUrl,
+                          apiKey
+                        ).then((response) => {
+                          if (response.status === 200) {
+                            // Redirect to dataset page
+                            window.location.replace(datasetPageUrl);
                           }
-                        );
+                        });
                       } else if (values.saveDraft) {
                         setDraftSaved(new Date());
                         setSubmitting(false);
@@ -344,8 +348,8 @@ const MetadataForm = (props) => {
                     setSubmitting(false);
                   });
               } else if (values.publish) {
-                // Update dataset state: 'draft' => 'active'
-                Api.patchDataset(curDatasetId, { state: 'active' }, apiUrl, apiKey)
+                // Update dataset state: 'publishing_status' => 'published'
+                Api.patchDataset(curDatasetId, { publishing_status: 'Published' }, apiUrl, apiKey)
                   .then((res) => {
                     if (res.status === 200) {
                       // Redirect to dataset page

--- a/metadata-app/src/components/MetadataForm/index.js
+++ b/metadata-app/src/components/MetadataForm/index.js
@@ -314,8 +314,14 @@ const MetadataForm = (props) => {
               const datasetPageUrl = `${apiUrlObject.origin}/dataset/${curDatasetId}`;
               if (resourceMetadataChanged) {
                 Api.createResource(curDatasetId, values.resource, apiUrl, apiKey)
-                  .then((res) => {
+                  .then(async (res) => {
                     if (res.status === 200) {
+                      // Make a dataset non private if user uploaded a file into
+                      // filestore so that it can be accessed without restriction
+                      if (values.resource.upload) {
+                        await Api.patchDataset(curDatasetId, { private: false }, apiUrl, apiKey);
+                      }
+
                       if (values.publish) {
                         // Update dataset state: 'publishing_status' => 'published'
                         Api.patchDataset(

--- a/metadata-app/src/components/MetadataForm/index.js
+++ b/metadata-app/src/components/MetadataForm/index.js
@@ -298,6 +298,7 @@ const MetadataForm = (props) => {
             savedResources: 0,
             lastSavedResource: null,
             saveDraft: false,
+            publishing_status: formValues.publishing_status,
           }}
           enableReinitialize="true"
           validateOnChange={false}

--- a/metadata-app/src/components/MetadataForm/index.js
+++ b/metadata-app/src/components/MetadataForm/index.js
@@ -370,6 +370,11 @@ const MetadataForm = (props) => {
               } else if (values.saveDraft) {
                 setDraftSaved(new Date());
                 setSubmitting(false);
+              } else {
+                // This happens when non of resource metadata is provided and
+                // user clicks "Save and add another" button. Should we display
+                // an error message here?
+                setSubmitting(false);
               }
             } else {
               setAlert(

--- a/metadata-app/src/components/RequiredMetadata/__snapshots__/index.test.js.snap
+++ b/metadata-app/src/components/RequiredMetadata/__snapshots__/index.test.js.snap
@@ -820,7 +820,6 @@ exports[`Renders RequiredMetadata component 1`] = `
       >
         <button
           class="usa-button usa-button--outline"
-          style="display: none;"
           type="button"
         >
           Save draft

--- a/metadata-app/src/components/RequiredMetadata/index.js
+++ b/metadata-app/src/components/RequiredMetadata/index.js
@@ -444,7 +444,6 @@ const RequiredMetadata = (props) => {
 
       <div className="margin-top-6 clearfix">
         <button
-          style={{ display: 'none' }}
           className="usa-button usa-button--outline"
           type="button"
           onClick={async () => {

--- a/metadata-app/src/components/RequiredMetadata/index.js
+++ b/metadata-app/src/components/RequiredMetadata/index.js
@@ -443,16 +443,20 @@ const RequiredMetadata = (props) => {
       </div>
 
       <div className="margin-top-6 clearfix">
-        <button
-          className="usa-button usa-button--outline"
-          type="button"
-          onClick={async () => {
-            await setFieldValue('saveDraft', true);
-            submitForm();
-          }}
-        >
-          Save draft
-        </button>
+        {values.publishing_status === 'Published' ? (
+          ''
+        ) : (
+          <button
+            className="usa-button usa-button--outline"
+            type="button"
+            onClick={async () => {
+              await setFieldValue('saveDraft', true);
+              submitForm();
+            }}
+          >
+            Save draft
+          </button>
+        )}
         <button
           className="usa-button float-right margin-right-0"
           type="button"

--- a/metadata-app/src/components/ResourceUpload/__snapshots__/index.test.js.snap
+++ b/metadata-app/src/components/ResourceUpload/__snapshots__/index.test.js.snap
@@ -529,7 +529,6 @@ exports[`Renders Resource Upload component 1`] = `
       >
         <button
           class="usa-button usa-button--outline"
-          style="display: none;"
           type="button"
         >
           Save draft

--- a/metadata-app/src/components/ResourceUpload/index.js
+++ b/metadata-app/src/components/ResourceUpload/index.js
@@ -259,7 +259,6 @@ const ResourceUpload = (props) => {
 
       <div className="margin-top-6 clearfix">
         <button
-          style={{ display: 'none' }}
           className="usa-button usa-button--outline"
           type="button"
           onClick={() => {

--- a/metadata-app/src/components/ResourceUpload/index.js
+++ b/metadata-app/src/components/ResourceUpload/index.js
@@ -258,18 +258,21 @@ const ResourceUpload = (props) => {
       )}
 
       <div className="margin-top-6 clearfix">
-        <button
-          className="usa-button usa-button--outline"
-          type="button"
-          onClick={() => {
-            setFieldValue('publish', false);
-            setFieldValue('saveDraft', true);
-            submitForm();
-          }}
-          disabled={isSubmitting}
-        >
-          Save draft
-        </button>
+        {values.publishing_status === 'Published' ? (
+          ''
+        ) : (
+          <button
+            className="usa-button usa-button--outline"
+            type="button"
+            onClick={async () => {
+              await setFieldValue('publish', false);
+              await setFieldValue('saveDraft', true);
+              submitForm();
+            }}
+          >
+            Save draft
+          </button>
+        )}
         <div className="float-right">
           <button
             className="usa-button usa-button--outline"
@@ -331,6 +334,7 @@ ResourceUpload.propTypes = {
     publish: PropTypes.bool,
     savedResources: PropTypes.number,
     lastSavedResource: PropTypes.string,
+    publishing_status: PropTypes.string,
   }),
 };
 


### PR DESCRIPTION
* the problem with validation of existing url is now resolved - https://github.com/GSA/USMetadata/pull/50
* parent dataset one is a bit tricky as our previous implementation was wrong (there is no way of getting private datasets over api in ckan 2.5.2. That feature was added in later versions.) So I've looked how it was done in the old form and needed to create a new API endpoint "parent_dataset_options" in this extension. The only regression now is that when parent is set and you go to edit mode, it displays dataset id instead of a nice title.)

TODO:

* [x] integration tests
* [x] switch "private: false" if user uploads a file