### PR TITLE
Display parent dataset title instead of random id

### DIFF
--- a/cypress/integration/additional-metadata.spec.js
+++ b/cypress/integration/additional-metadata.spec.js
@@ -104,7 +104,7 @@ describe('Parent Dataset', () => {
     });
   });
 
-  it('Able to select', () => {
+  it('Able to select and displays parent dataset with a human-readable title', () => {
     cy.visit('/dataset/new-metadata');
     cy.requiredMetadata(childTitle);
     cy.get('.react-autosuggest__container input').type(parentTitle);
@@ -114,9 +114,7 @@ describe('Parent Dataset', () => {
     cy.get('button[type=button]').contains('Save and Continue').click();
     cy.wait('@packageUpdate');
     cy.resourceUploadWithUrlAndPublish();
-  });
-
-  it('Displays parent dataset with a human-readable title', () => {
+    // Go to edit mode and check if parent dataset title is displayed
     cy.visit('/dataset/edit-new/' + childTitle);
     cy.get('[role="link"]').contains('Additional Metadata').click();
     cy.get('.react-autosuggest__container input').should('have.value', parentTitle);

--- a/cypress/integration/additional-metadata.spec.js
+++ b/cypress/integration/additional-metadata.spec.js
@@ -113,10 +113,15 @@ describe('Parent Dataset', () => {
     cy.intercept('/api/3/action/package_update').as('packageUpdate');
     cy.get('button[type=button]').contains('Save and Continue').click();
     cy.wait('@packageUpdate');
+    cy.intercept('/api/3/action/package_patch').as('packagePatch');
     cy.resourceUploadWithUrlAndPublish();
+    cy.wait('@packagePatch');
     // Go to edit mode and check if parent dataset title is displayed
+    cy.intercept('/api/3/action/package_show').as('packageShow');
     cy.visit('/dataset/edit-new/' + childTitle);
+    cy.wait('@packageShow');
     cy.get('[role="link"]').contains('Additional Metadata').click();
+    cy.wait('@packageShow');
     cy.get('.react-autosuggest__container input').should('have.value', parentTitle);
   });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -16,7 +16,7 @@ Cypress.Commands.add('logout', () => {
 Cypress.Commands.add('createOrg', () => {
   cy.visit('/organization/new');
   cy.get('input[name=title]').type('test-123');
-  cy.get('.form-actions .btn-primary').click();
+  cy.get('.form-actions .btn-primary').click({ failOnStatusCode: false });
 });
 
 Cypress.Commands.add('createUser', (username) => {

--- a/metadata-app/src/components/AdditionalMetadata/index.js
+++ b/metadata-app/src/components/AdditionalMetadata/index.js
@@ -274,8 +274,7 @@ const AdditionalMetadata = (props) => {
               name="parentDataset"
               type="string"
               value={values.parentDataset}
-              // TODO - inputValue should be replaced with parent dataset name
-              inputValue={values.parentDataset}
+              inputValue={values.parentDatasetTitle}
               placeholder="Select parent dataset"
               helptext="Start typing to see list of matching datasets by title"
               fetchOpts={api.fetchParentDatasets}
@@ -364,6 +363,7 @@ AdditionalMetadata.propTypes = {
     isPartOf: PropTypes.string,
     isParent: PropTypes.string,
     parentDataset: PropTypes.string,
+    parentDatasetTitle: PropTypes.string,
     publishing_status: PropTypes.string,
   }),
 };

--- a/metadata-app/src/components/MetadataForm/index.js
+++ b/metadata-app/src/components/MetadataForm/index.js
@@ -114,6 +114,18 @@ const MetadataForm = (props) => {
         apiRes.description = result.notes; // TODO: move this to api helpers
         setFormValues(Object.assign({}, formValues, apiRes));
         setCurDatasetId(apiRes.id);
+        // Fetch parent dataset's human-readable title:
+        if (apiRes.parentDataset) {
+          Api.fetchDataset(apiRes.parentDataset, apiUrl, apiKey)
+            .then((parent) => {
+              setFormValues(
+                Object.assign({}, formValues, {
+                  parentDatasetTitle: parent.title,
+                })
+              );
+            })
+            .catch(handleError);
+        }
       })
       .catch(handleError);
   }

--- a/metadata-app/src/components/MetadataForm/index.js
+++ b/metadata-app/src/components/MetadataForm/index.js
@@ -112,19 +112,20 @@ const MetadataForm = (props) => {
       .then((result) => {
         const apiRes = Object.assign({}, result);
         apiRes.description = result.notes; // TODO: move this to api helpers
-        setFormValues(Object.assign({}, formValues, apiRes));
         setCurDatasetId(apiRes.id);
         // Fetch parent dataset's human-readable title:
         if (apiRes.parentDataset) {
           Api.fetchDataset(apiRes.parentDataset, apiUrl, apiKey)
             .then((parent) => {
               setFormValues(
-                Object.assign({}, formValues, {
+                Object.assign({}, formValues, apiRes, {
                   parentDatasetTitle: parent.title,
                 })
               );
             })
             .catch(handleError);
+        } else {
+          setFormValues(Object.assign({}, formValues, apiRes));
         }
       })
       .catch(handleError);


### PR DESCRIPTION
When editing a dataset, in additional metadata page, we have parent dataset value as an id which is confusing:

* not human readable;
* not consistent with what a user has selected when creating a dataset (dataset title).

This PR fixes the UX so that user sees a parent dataset title instead of id.