### PR TITLE
Feature/edit resource url

### DIFF
--- a/config/production.ini
+++ b/config/production.ini
@@ -56,7 +56,7 @@ ckan.datastore.default_fts_index_method = gist
 
 ## Site Settings
 
-ckan.site_url = http://localhost:5000
+ckan.site_url = http://127.0.0.1:5000
 #ckan.use_pylons_response_cleanup_middleware = true
 
 ## Authorization Settings

--- a/cypress.json
+++ b/cypress.json
@@ -1,4 +1,4 @@
 {
-  "baseUrl": "http://localhost:5000",
+  "baseUrl": "http://127.0.0.1:5000",
   "chromeWebSecurity": false
 }

--- a/cypress/integration/edit-dataset.spec.js
+++ b/cypress/integration/edit-dataset.spec.js
@@ -202,6 +202,7 @@ describe('Editing an existing dataset', () => {
     cy.get(`#edit-${resourceToBeEdited}`).click();
     cy.contains('Save');
     cy.get('input[name=resource\\.name]').type(`-updated`);
+    cy.get('input[name=resource\\.url]').type(`-updated`);
     cy.contains('Save').click();
     cy.get('input[name=resource\\.name]').should('have.value', '');
     cy.get('button[type=button]').contains('Finish and publish').click();
@@ -212,7 +213,6 @@ describe('Editing an existing dataset', () => {
     cy.contains('Resource Upload').click();
     cy.intercept('/api/3/action/resource_delete').as('resourceDelete');
     cy.contains(resourceToBeDeleted);
-    cy.contains('2 resources saved in total');
     cy.get(`#delete-${resourceToBeDeleted}`).click();
     cy.wait('@resourceDelete');
     cy.contains(resourceToBeDeleted).should('not.exist');

--- a/cypress/integration/resource-upload.spec.js
+++ b/cypress/integration/resource-upload.spec.js
@@ -112,17 +112,16 @@ describe('Resource Upload page', () => {
 
   it('Saves resource and displays expected message', () => {
     const exampleUrl = 'https://example.com/data.csv';
-    const expectedMessage1 = `Resource saved: [${exampleUrl}] (1 resources saved in total).`;
-    const expectedMessage2 = 'You can edit any saved resource after clicking "Finish and publish"';
+    const resourceName = chance.word();
+    const expectedMessage1 = `Resource saved: [${resourceName}] (1 resources saved in total).`;
     cy.requiredMetadata(titleAndName);
     cy.additionalMetadata();
     cy.get('button[type=button]')
       .contains('Save and Continue')
       .click()
       .then(() => {
-        cy.resourceUploadWithUrlAndSave(exampleUrl);
+        cy.resourceUploadWithUrlAndSave(exampleUrl, resourceName);
         cy.contains(expectedMessage1);
-        cy.contains(expectedMessage2);
       });
   });
 

--- a/metadata-app/src/api/index.js
+++ b/metadata-app/src/api/index.js
@@ -496,7 +496,15 @@ const createResource = (packageId, opts, apiUrl, apiKey) => {
 };
 
 const updateResource = (resource, apiUrl, apiKey) => {
-  const body = encodeValues(clone(resource));
+  let body;
+  if (resource.upload) {
+    body = new FormData();
+    Object.keys(resource).forEach((item) => {
+      body.append(item, resource[item]);
+    });
+  } else {
+    body = encodeValues(clone(resource));
+  }
 
   return axios.post(`${apiUrl}resource_update`, body, {
     headers: {

--- a/metadata-app/src/components/MetadataForm/index.js
+++ b/metadata-app/src/components/MetadataForm/index.js
@@ -381,15 +381,11 @@ const MetadataForm = (props) => {
                         });
                         if (values.resourceAction !== 'delete') {
                           newResources.push(res.data.result);
-                          // if it was save operation then increment the # of saved resources
-                          // and save keep track of last saved resource
-                          if (values.resourceAction !== 'edit') {
-                            setFieldValue('savedResources', values.savedResources + 1);
-                            setFieldValue(
-                              'lastSavedResource',
-                              values.resource.url || values.resource.name
-                            );
-                          }
+                          setFieldValue('savedResources', values.savedResources + 1);
+                          setFieldValue(
+                            'lastSavedResource',
+                            values.resource.name || values.resource.url
+                          );
                         }
 
                         setFieldValue('resources', newResources);

--- a/metadata-app/src/components/ResourceUpload/index.js
+++ b/metadata-app/src/components/ResourceUpload/index.js
@@ -56,7 +56,11 @@ const ResourceUpload = (props) => {
 
   const editResource = (res) => {
     setFieldValue('resourceAction', 'edit');
+    setUploadDataFileActive(false);
     setFieldValue('resource', res);
+    setFieldValue('resource.size', '');
+    setFieldValue('resource.webstore_last_updated', '');
+    setFieldValue('resource.cache_last_updated', '');
   };
 
   const deleteResource = (res) => {
@@ -126,80 +130,72 @@ const ResourceUpload = (props) => {
         </div>
       )}
       {
-        // if it's not edit mode then show the data upload field
-        resourceAction !== 'edit' && (
-          <div className="grid-row margin-top-3">
-            <div className="grid-col-12">
-              {/* eslint-disable-next-line */}
-              <label className="usa-label">Data</label>
-              {/* eslint-disable-next-line */}
-              {linkToDataIsActive || url ? (
-                <div>
-                  <p className="usa-helptext">
-                    {`If you are linking to a dataset, please include "https://" at the beginning
+        <div className="grid-row margin-top-3">
+          <div className="grid-col-12">
+            {/* eslint-disable-next-line */}
+            <label className="usa-label">Data</label>
+            {/* eslint-disable-next-line */}
+            {linkToDataIsActive || url ? (
+              <div>
+                <p className="usa-helptext">
+                  {`If you are linking to a dataset, please include "https://" at the beginning
                 of your URL.`}
-                  </p>
-                  <WrappedField
-                    hidden={!linkToDataIsActive}
-                    id="url"
-                    name="resource.url"
-                    type="url"
-                    value={url}
-                    onClick={() => {
-                      setFieldValue('resource.url', '');
-                      setLinkToDataActive(false);
-                    }}
-                    errors={errors}
-                  />
-                </div>
-              ) : uploadDataFileIsActive ? (
+                </p>
                 <WrappedField
-                  name="resource.fileName"
-                  type="label"
-                  value={resource.fileName}
+                  hidden={!linkToDataIsActive}
+                  id="url"
+                  name="resource.url"
+                  type="url"
+                  value={url}
                   onClick={() => {
-                    setFieldValue('resource.upload', null);
-                    setFieldValue('resource.fileName', '');
-                    setFieldValue('resource.name', '');
-                    setFieldValue('resource.description', '');
-                    setFieldValue('resource.format', '');
-                    setFieldValue('resource.mimetype', '');
-                    setUploadDataFileActive(false);
+                    setFieldValue('resource.url', '');
+                    setLinkToDataActive(false);
                   }}
+                  errors={errors}
                 />
-              ) : (
-                <>
-                  <br />
-                  {/* eslint-disable-next-line */}
-                  <label tabIndex="0" htmlFor="upload" className="usa-button usa-button--base">
-                    <i className="fa fa-cloud-upload" aria-hidden="true" /> Upload data
-                  </label>
-                  <input
-                    id="upload"
-                    name="resource.upload"
-                    type="file"
-                    onChange={handleFileChange}
-                  />
-                  {/* eslint-disable */}
-                  <label
-                    tabIndex="0"
-                    htmlFor="url"
-                    className="usa-button usa-button--base"
-                    onClick={() => {
-                      setLinkToDataActive(!linkToDataIsActive);
-                    }}
-                  >
-                    <i className="fa fa-link" aria-hidden="true" /> Link to data
-                  </label>
-                  {/* eslint-enable */}
-                  <p className="usa-helptext">
-                    Formats accepted include the following: TXT, HTML, TSV, CSV, ODT, XML, Perl.
-                  </p>
-                </>
-              )}
-            </div>
+              </div>
+            ) : uploadDataFileIsActive ? (
+              <WrappedField
+                name="resource.fileName"
+                type="label"
+                value={resource.fileName}
+                onClick={() => {
+                  setFieldValue('resource.upload', null);
+                  setFieldValue('resource.fileName', '');
+                  setFieldValue('resource.name', '');
+                  setFieldValue('resource.description', '');
+                  setFieldValue('resource.format', '');
+                  setFieldValue('resource.mimetype', '');
+                  setUploadDataFileActive(false);
+                }}
+              />
+            ) : (
+              <>
+                <br />
+                {/* eslint-disable-next-line */}
+                <label tabIndex="0" htmlFor="upload" className="usa-button usa-button--base">
+                  <i className="fa fa-cloud-upload" aria-hidden="true" /> Upload data
+                </label>
+                <input id="upload" name="resource.upload" type="file" onChange={handleFileChange} />
+                {/* eslint-disable */}
+                <label
+                  tabIndex="0"
+                  htmlFor="url"
+                  className="usa-button usa-button--base"
+                  onClick={() => {
+                    setLinkToDataActive(!linkToDataIsActive);
+                  }}
+                >
+                  <i className="fa fa-link" aria-hidden="true" /> Link to data
+                </label>
+                {/* eslint-enable */}
+                <p className="usa-helptext">
+                  Formats accepted include the following: TXT, HTML, TSV, CSV, ODT, XML, Perl.
+                </p>
+              </>
+            )}
           </div>
-        )
+        </div>
       }
       <div className="grid-row margin-top-3">
         <div className="grid-col-12">

--- a/metadata-app/src/components/ResourceUpload/index.js
+++ b/metadata-app/src/components/ResourceUpload/index.js
@@ -263,20 +263,17 @@ const ResourceUpload = (props) => {
           </button>
         </div>
       </div>
-      {values.savedResources > 0 ? (
+      {values.lastSavedResource && resources.length ? (
         <div className="grid-row margin-top-3">
           <div className="grid-col-12">
             <div className="usa-alert usa-alert--success usa-alert--slim usa-alert--no-icon">
               <div className="usa-alert__body">
                 <p className="usa-alert__text">
                   <i>
-                    Resource saved: [{values.lastSavedResource}] ({values.savedResources} resources
-                    saved in total).
+                    Resource saved: [{values.lastSavedResource}] ({resources.length} resources saved
+                    in total).
                   </i>
                   <br />
-                  <i>
-                    You can edit any saved resource after clicking &quot;Finish and publish&quot;.
-                  </i>
                 </p>
               </div>
             </div>

--- a/metadata-app/src/components/ResourceUpload/validationSchema.js
+++ b/metadata-app/src/components/ResourceUpload/validationSchema.js
@@ -10,12 +10,7 @@ export default yup.object().shape({
       .string()
       .url(
         'If you are linking to a dataset, please include "https://" at the beginning of your URL.'
-      )
-      .when('id', (id, schema) => {
-        // if id exists meaning that it's in edit mode then pass the url validation,
-        // since in the form there upload field is hidden
-        return id ? yup.string() : schema;
-      }),
+      ),
     upload: yup.mixed(),
   }),
 });


### PR DESCRIPTION
Covers the missing part in #179 

- [x] Remove second sentence in the success message for saved/edited resoruces
- [x] Number of resources in success message should be equal to the total number of resources (including saved and edited) for the given dataset
- [x] The bottom success message should appear also in case of successful edit operation
- [x] Resource URL should be editable as well 

Demo
https://www.loom.com/share/12e9317cae664c57b388d134c202491c?focus_title=1&muted=1&from_recorder=1