### PR TITLE
Bug fix in sandbox when re-uploading a file.

### DIFF
--- a/metadata-app/src/api/index.js
+++ b/metadata-app/src/api/index.js
@@ -502,7 +502,9 @@ const updateResource = (resource, apiUrl, apiKey) => {
   if (resource.upload) {
     body = new FormData();
     Object.keys(resource).forEach((item) => {
-      body.append(item, resource[item]);
+      if (resource[item] !== null) {
+        body.append(item, resource[item]);
+      }
     });
   } else {
     body = encodeValues(clone(resource));


### PR DESCRIPTION
Don't pass null values when posting form data with `resource_update` API call. It causes unexpected behaviour from the CKAN API raising validation error. Specifically, it fails with 'wrong date format' error for 'last_modified' attribute. The challenge is that we couldn't reproduce it within local inventory instance so we needed to develop/debug against live sandbox (you can do it by running React app locally and pointing to sandbox).