### PR TITLE
A new paster command for importing publishers

### DIFF
--- a/ckanext/dcat_usmetadata/cli.py
+++ b/ckanext/dcat_usmetadata/cli.py
@@ -10,17 +10,24 @@ class DCATUSMetadataCommand(cli.CkanCommand):
     Usage:
 
         publishers-import <path_to_file> - imports publishers from the CSV file.
+
+        Headers of expected CSV data (ordered):
+        1. organization
+        2. publisher
+        3. publisher_1
+        4. publisher_2
+        5. publisher_3
+        6. publisher_4
+        7. publisher_5
     '''
 
     summary = __doc__.split('\n')[0]
     usage = __doc__
 
     def command(self):
-        if self.args and self.args[0] == 'publishers-import':
-            print 'hey!!!'
-            if len(self.args) != 2:
-                print "This command requires an argument\n"
-                print self.usage
-                sys.exit(1)
+        if len(self.args) == 1:
+            path_to_file = self.args[0]
         else:
+            print "This command requires an argument\n"
             print self.usage
+            sys.exit(1)

--- a/ckanext/dcat_usmetadata/cli.py
+++ b/ckanext/dcat_usmetadata/cli.py
@@ -11,7 +11,8 @@ class DCATUSMetadataCommand(cli.CkanCommand):
 
     Usage:
 
-        publishers-import <path_to_file> - imports publishers from the CSV file.
+        publishers-import <path_to_file> - imports publishers from the \
+        CSV file.
 
         Headers of expected CSV data (ordered):
         1. organization

--- a/ckanext/dcat_usmetadata/cli.py
+++ b/ckanext/dcat_usmetadata/cli.py
@@ -1,0 +1,26 @@
+import sys
+
+import ckan.lib.cli as cli
+import ckan.plugins as p
+
+
+class DCATUSMetadataCommand(cli.CkanCommand):
+    '''Import publishers from the CSV data to CKAN group extra.
+
+    Usage:
+
+        publishers-import <path_to_file> - imports publishers from the CSV file.
+    '''
+
+    summary = __doc__.split('\n')[0]
+    usage = __doc__
+
+    def command(self):
+        if self.args and self.args[0] == 'publishers-import':
+            print 'hey!!!'
+            if len(self.args) != 2:
+                print "This command requires an argument\n"
+                print self.usage
+                sys.exit(1)
+        else:
+            print self.usage

--- a/ckanext/dcat_usmetadata/cli.py
+++ b/ckanext/dcat_usmetadata/cli.py
@@ -42,7 +42,7 @@ class DCATUSMetadataCommand(cli.CkanCommand):
     def import_publishers(self, path_to_file):
         with open(path_to_file, 'rb') as csvfile:
             reader = csv.reader(csvfile)
-            first_row = next(reader, None)  # skip the headers
+            next(reader, None)  # skip the headers
             data = list(reader)
             # Generate publishers extra for each CKAN org:
             for org in self.get_orgs_to_process(data):
@@ -68,7 +68,8 @@ class DCATUSMetadataCommand(cli.CkanCommand):
                 'organization_show')({}, {'id': org})
             org_extras = org_metadata.get('result', {}).get('extras', [])
             index_of_publisher_extra = next(
-                (i for i, item in enumerate(org_extras) if item['key'] == 'publisher'), None)
+                (i for i, item in enumerate(org_extras)
+                    if item['key'] == 'publisher'), None)
             if index_of_publisher_extra:
                 org_extras[index_of_publisher_extra]['value'] = json.dumps(
                     publishers_tree)

--- a/ckanext/dcat_usmetadata/publishers.test.csv
+++ b/ckanext/dcat_usmetadata/publishers.test.csv
@@ -1,0 +1,7 @@
+organization,publisher,publisher_1,publisher_2,publisher_3,publisher_4,publisher_5
+test-organization,top level publisher,,,,,
+test-organization,top level publisher,first level publisher,,,,
+test-organization,top level publisher,first level publisher,second level publisher,,,
+test-organization,top level publisher,first level publisher,second level publisher,third level publisher,,
+test-organization,top level publisher,first level publisher,second level publisher,third level publisher,fourth level publisher,
+test-organization,top level publisher,first level publisher,second level publisher,third level publisher,fourth level publisher,fifth level publisher

--- a/cypress/integration/publishers.spec.js
+++ b/cypress/integration/publishers.spec.js
@@ -1,0 +1,15 @@
+describe('Publishers linked to CKAN org', () => {
+  it('Has publishers extra in CKAN org metadata', () => {
+    cy.login();
+    cy.request('GET', '/api/3/action/organization_show?id=test-organization').then((response) => {
+      expect(response.status).to.eq(200);
+      const publisherExtra = response.body.result.extras.find((x) => x.key === 'publisher');
+      assert.isObject(publisherExtra, 'extra is found');
+      assert.isString(publisherExtra.value, 'its value is string');
+      const publishers = JSON.parse(publisherExtra.value);
+      expect(publishers.length).to.eq(6);
+      expect(publishers[0].length).to.eq(2);
+      expect(publishers[5].length).to.eq(7);
+    });
+  });
+});

--- a/seed.sh
+++ b/seed.sh
@@ -47,6 +47,9 @@ curl -X POST \
 
 echo ''
 
+# Import publishers to 'test-organization'
+/usr/lib/ckan/bin/paster --plugin=ckanext-dcat_usmetadata publishers-import /usr/lib/ckan/ckanext/dcat-usmetadata/ckanext/dcat_usmetadata/publishers.test.csv -c /etc/ckan/production.ini
+
 # Adding dataset(s) via API
 curl -X POST \
   http://localhost:5000/api/3/action/package_create \

--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,9 @@ setup(
 
         [babel.extractors]
         ckan = ckan.lib.extract:extract_ckan
+
+        [paste.paster_command]
+        publishers-import = ckanext.dcat_usmetadata.cli:DCATUSMetadataCommand
     ''',
 
     # If you are changing from the default layout of your extension, you may

--- a/yarn.lock
+++ b/yarn.lock
@@ -2453,7 +2453,7 @@ array-flatten@^2.1.0:
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-2.1.2.tgz#24ef80a28c1a893617e2149b0c6d0d788293b099"
   integrity sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==
 
-array-includes@^3.0.3, array-includes@^3.1.1:
+array-includes@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.1.tgz#cdd67e6852bdf9c1215460786732255ed2459348"
   integrity sha512-c2VXaCHl7zPsvpkFsw4nxvFie4fh1ur9bpcgsVkIjqn0H/Xwdg+7fv3n2r/isyS8EBj5b06M9kHyZuIr4El6WQ==


### PR DESCRIPTION
Usage:

`paster --plugin=ckanext-dcat_usmetadata publishers-import path-to-csv -c /etc/ckan/production.ini`

This PR adds a new CLI command for importing publishers into CKAN db (organization's extra metadata).

The CSV data should have the following format:

```
organization,publisher,publisher_1,publisher_2,publisher_3,publisher_4,publisher_5
agricultural-marketing-service-department-of-agriculture,Department of Agriculture,Agricultural Marketing Service,,,,
ars-usda-gov,Department of Agriculture,Agricultural Research Service,,,,
aphis-usda-gov,Department of Agriculture,Animal and Plant Health Inspection Service,,,,
risk-management-agency-department-of-agriculture,Department of Agriculture,Departmental Management,,,,
usda-gov,Department of Agriculture,Office of Chief Information Officer,,,,
usda-gov,Department of Agriculture,Economic Research Service,,,,
usda-gov,Department of Agriculture,Farm Service Agency,,,,
usda-gov,Department of Agriculture,Food and Nutrition Service,,,,
usda-gov,Department of Agriculture,Food Safety and Inspection Service,,,,
usda-gov,Department of Agriculture,Foreign Agricultural Service,,,,
usda-gov,Department of Agriculture,National Agricultural Statistics Service,,,,
usda-gov,Department of Agriculture,National Institute of Food and Agriculture,,,,
usda-gov,Department of Agriculture,Natural Resources Conservation Service,Colorado State University,,,
usda-gov,Department of Agriculture,Rural Development,,,,
usda-gov,Department of Agriculture,GIPSA,Federal Grain Inspection Service,,,
usda-gov,Department of Agriculture,Natural Resources Conservation Service,,,,
usda-gov,Department of Agriculture,US Forest Service,,,,
```

With this PR test publishers are imported to `test-organization` when running `yarn up-with-data` command. See https://github.com/GSA/ckanext-dcat_usmetadata/pull/229/commits/4c82ecc14dc46388b69a7e5bfc1ed8e9e09e5eac