### PR TITLE
Fix publishers import

### DIFF
--- a/ckanext/dcat_usmetadata/cli.py
+++ b/ckanext/dcat_usmetadata/cli.py
@@ -67,7 +67,7 @@ class DCATUSMetadataCommand(cli.CkanCommand):
         try:
             org_metadata = p.toolkit.get_action(
                 'organization_show')({}, {'id': org})
-            org_extras = org_metadata.get('result', {}).get('extras', [])
+            org_extras = org_metadata.get('extras', [])
             index_of_publisher_extra = next(
                 (i for i, item in enumerate(org_extras)
                     if item['key'] == 'publisher'), None)

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # http://packaging.python.org/en/latest/tutorial.html#version
-    version='0.2.20',
+    version='0.2.21',
 
     description='''DCAT USMetadata Form App for CKAN''',
     long_description=long_description,


### PR DESCRIPTION
Fixed issue GSA/datagov-deploy#3175 that `sub-agencies` is lost when publishers-import is run.