### PR TITLE
use R/P1W for weekly accrualPeriodicity

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -125,7 +125,7 @@ Cypress.Commands.add('additionalMetadata', (isparent) => {
   cy.get('#category-option-yes').parent('.form-group').click();
   cy.get('input[name=data_dictionary]').clear().type(chance.url());
   cy.get('select[name=describedByType]').select('text/csv');
-  cy.get('select[name=accrualPeriodicity]').select('R/P7D');
+  cy.get('select[name=accrualPeriodicity]').select('R/P1W');
   cy.get('input[name=homepage_url]').clear().type(chance.url());
   cy.get('select[name=languageSubTag]').select('en');
   cy.get('select[name=languageRegSubTag]').select('US');

--- a/metadata-app/src/components/AdditionalMetadata/__snapshots__/index.test.js.snap
+++ b/metadata-app/src/components/AdditionalMetadata/__snapshots__/index.test.js.snap
@@ -585,7 +585,7 @@ exports[`Renders RequiredMetadata component 1`] = `
                 Daily
               </option>
               <option
-                value="R/P7D"
+                value="R/P1W"
               >
                 Weekly
               </option>

--- a/metadata-app/src/components/AdditionalMetadata/publishingFrequencyList.json
+++ b/metadata-app/src/components/AdditionalMetadata/publishingFrequencyList.json
@@ -12,7 +12,7 @@
     "label": "Daily"
   },
   {
-    "value": "R/P7D",
+    "value": "R/P1W",
     "label": "Weekly"
   },
   {


### PR DESCRIPTION
R/P7D or R/P1W?

data.json expects R/P1W.
https://github.com/GSA/ckanext-datajson/blob/4ca1ca31cfcc23d6610c13693049fcfc83696d08/ckanext/datajson/datajsonvalidator.py#L64

R/P1W is official
https://resources.data.gov/schemas/dcat-us/v1.1/iso8601_guidance/#accrualperiodicity