### PR TITLE
Don't delete resource_type

### DIFF
--- a/metadata-app/src/api/index.js
+++ b/metadata-app/src/api/index.js
@@ -89,7 +89,7 @@ const encodeValues = (obj) => {
 const serializeResource = (resource) => {
   const serializedResource = clone(resource);
 
-  delete serializedResource.resource_type;
+  // delete serializedResource.resource_type;
 
   if (serializedResource.urlType) {
     if (
@@ -582,6 +582,7 @@ const createDataset = (opts, apiUrl, apiKey) => {
 
 const createResource = (packageId, opts, apiUrl, apiKey) => {
   let body;
+  console.log(opts);
   if (opts.upload) {
     body = new FormData();
     body.append('package_id', packageId);


### PR DESCRIPTION
Related to https://github.com/GSA/data.gov/issues/3788

Through investigation, it would seem as deleting the resource type breaks datajson validation as well as creates a UI bug since the field does not have any data and can't be shown properly to the end-user