### PR TITLE
Fix pypi release

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 include README.md
 include LICENSE
 include requirements.txt
-recursive-include ckanext/dcat_usmetadata *.html *.json *.js *.less *.css *.mo
+recursive-include ckanext/dcat_usmetadata *.html *.json *.js *.less *.css *.mo *.yml
 recursive-include ckanext/dcat_usmetadata/public/assets *

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # http://packaging.python.org/en/latest/tutorial.html#version
-    version='0.3.1',
+    version='0.3.5',
 
     description='''DCAT USMetadata Form App for CKAN''',
     long_description=long_description,


### PR DESCRIPTION
Related to https://github.com/GSA/data.gov/issues/3613

`webassets.yml` was missing from the release.