### PR TITLE
Bump version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # http://packaging.python.org/en/latest/tutorial.html#version
-    version='0.3.5',
+    version='0.3.6',
 
     description='''DCAT USMetadata Form App for CKAN''',
     long_description=long_description,


### PR DESCRIPTION
Missed changing the version number: https://github.com/GSA/ckanext-dcat_usmetadata/runs/7236968461?check_suite_focus=true

Bumped the version to be able to publish a new version...