### PR TITLE
Dev-requirements are NOT necessary for PyPI release

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
           sed -i "s/version='[0-9]\{1,2\}.[0-9]\{1,4\}.[0-9]\{1,4\}',/version='${{github.event.inputs.version_no}}',/g" setup.py
       - name: Create packages
         run: |
-          pip install -r dev-requirements.txt
+          # pip install -r dev-requirements.txt
           python setup.py sdist
           python setup.py bdist_wheel
       - name: pypi-publish

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
     needs: lint-python
     strategy:
       matrix:
-        ckan-version: [2.9, 2.8]
+        ckan-version: [2.9]
       fail-fast: false
 
     name: Pytests for CKAN ${{ matrix.ckan-version }}
@@ -97,13 +97,6 @@ jobs:
         pip install -e .
         source $ENV_FILE
         ckan -c test.ini db init
-    - name: Install requirements and Setup (py2)
-      if: ${{ matrix.ckan-version == '2.8' }}
-      run: |
-        pip install -r requirements-py2.txt
-        pip install -e .
-        source $ENV_FILE
-        paster --plugin=ckan db init -c test.ini
     - name: Run tests
       run: |
         yarn build

--- a/README.md
+++ b/README.md
@@ -14,11 +14,10 @@ Make sure it is enabled in CKAN's plugins.
 
 This extension is compatible with these versions of CKAN.
 
-| CKAN version | Compatibility                                                    |
-| ------------ | ---------------------------------------------------------------- |
-| <=2.7        | no                                                               |
-| 2.8          | yes                                                              |
-| 2.9          | [complete](https://github.com/GSA/datagov-ckan-multi/issues/572) |
+| CKAN version | Compatibility                                               |
+| ------------ | ----------------------------------------------------------- |
+| <=2.8        | no                                                          |
+| 2.9          | [yes](https://github.com/GSA/datagov-ckan-multi/issues/572) |
 
 ### Installation
 


### PR DESCRIPTION
Related to https://github.com/GSA/data.gov/issues/3414

Optimize the publish action to only use the required tools.

Successful Run: https://github.com/GSA/ckanext-dcat_usmetadata/runs/7283030060?check_suite_focus=true