### PR TITLE
Pypi build needs to be pinned to node 16

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,9 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
       - name: Build Metadata UI App Files
         run: |
           yarn


### PR DESCRIPTION
Related to
- https://github.com/GSA/inventory-app/pull/584
- https://github.com/GSA/ckanext-dcat_usmetadata/pull/306
- https://github.com/GSA/data.gov/issues/4262