### PR TITLE
Update pypi version & make jest tests pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,12 @@ This extension is compatible with these versions of CKAN.
 
 | CKAN version | Compatibility |
 | ------------ | ------------- |
-| <=2.8        | no            |
-| 2.9          | yes           |
+| >=2.9        | yes           |
+| >=3.0        | no            |
 
 ### Installation
 
-To install this package, activate CKAN virtualenv (e.g. "source /path/to/virtenv/bin/activate"), then run
-
-```
-(virtualenv) pip install ckanext-dcat-usmetadata
-```
+Add `ckanext-dcat-usmetadata` to your requirements.txt, and then pip install
 
 In your CKAN .ini file add `dcat_usmetadata` to your enabled plugins:
 
@@ -33,7 +29,7 @@ In your CKAN .ini file add `dcat_usmetadata` to your enabled plugins:
 
 ### Commands
 
-### publishers-import
+#### publishers-import
 
 This extension adds a new CLI command for importing publishers linked to CKAN
 organizations. The [list of
@@ -184,6 +180,10 @@ To run e2e tests interactively use:
 ```bash
 yarn e2e:interactive
 ```
+
+### Locally installing this extention
+
+You can install this extension locally (to [inventory app](https://github.com/GSA/inventory-app), for example), but you must `yarn install` and then `yarn build` the JS/CSS prior to launching the app locally.
 
 ## Publishing a new version of the extension
 

--- a/metadata-app/src/api/index.js
+++ b/metadata-app/src/api/index.js
@@ -556,7 +556,7 @@ const makeHeaders = (apiKey, includeContentType = false) => {
   const token = window.document.querySelector('meta[name="_csrf_token"]');
   const headers = {
     'X-CKAN-API-Key': apiKey,
-    'X-CSRFToken': token.content,
+    'X-CSRFToken': token ? token.content : null,
   };
   const formHeader = { 'Content-Type': 'application/x-www-form-urlencoded' };
   return includeContentType ? Object.assign(headers, formHeader) : headers;

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # http://packaging.python.org/en/latest/tutorial.html#version
-    version='0.4.0',
+    version='0.4.2',
 
     description='''DCAT USMetadata Form App for CKAN''',
     long_description=long_description,


### PR DESCRIPTION
- Bumps Pypi version to match online
- Check CSRF token present before passing in content property
