### PR TITLE
bump version to fixup #312

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # http://packaging.python.org/en/latest/tutorial.html#version
-    version='0.4.2',
+    version='0.4.3',
 
     description='''DCAT USMetadata Form App for CKAN''',
     long_description=long_description,


### PR DESCRIPTION
bumps pypi version [for this](https://github.com/GSA/ckanext-dcat_usmetadata/pull/312). 

@btylerburton 