### PR TITLE
Unpin pypi github action to v1

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
           python setup.py sdist
           python setup.py bdist_wheel
       - name: pypi-publish
-        uses: pypa/gh-action-pypi-publish@v1.6.4
+        uses: pypa/gh-action-pypi-publish@v1
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
# Pull Request

Same as https://github.com/GSA/ckanext-geodatagov/pull/275, 

## About

<!-- any pertinent notes -->

The current [action version](https://github.com/pypa/gh-action-pypi-publish) is `v1.8.11`. This PR unpins the action to keep it up to date as `v1` changes take place. 
