### PR TITLE
add id to check_access, bump to 0.6.1

### DIFF
--- a/ckanext/dcat_usmetadata/blueprint.py
+++ b/ckanext/dcat_usmetadata/blueprint.py
@@ -60,7 +60,7 @@ def edit_metadata(id):
         abort(404, _('Dataset not found'))
 
     try:
-        check_access('package_update', context)
+        check_access('package_update', context, {'id': id})
     except NotAuthorized:
         abort(401, _('User %r not authorized to edit %s') % (c.user, id))
 

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # http://packaging.python.org/en/latest/tutorial.html#version
-    version="0.6.0",
+    version="0.6.1",
     description="""DCAT USMetadata Form App for CKAN""",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
fix an issue found in inventory after migrated to 2.11.0 that an editor can not edit a dataset.
https://github.com/GSA/data.gov/issues/5079#issuecomment-2648831450

- passing the package id into function `check_access`.
- bump Pypi version 0.6.1