### PR TITLE
Switch to CKAN 2.11 for Docker

### DIFF
--- a/.env
+++ b/.env
@@ -10,7 +10,6 @@ CKAN_SYSADMIN_NAME=admin
 CKAN_SYSADMIN_PASSWORD=password
 CKAN_SYSADMIN_EMAIL=your_email@example.com
 TZ=UTC
-CKAN_VERSION=2.10
 
 # Database connections (TODO: avoid duplication)
 CKAN_SQLALCHEMY_URL=postgresql://ckan_default:pass@db/ckan_test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,10 +79,10 @@ jobs:
       - name: cypress
         run: |
           source $ENV_FILE
-          CKAN_VERSION=2.10 yarn install
-          CKAN_VERSION=2.10 yarn build
-          CKAN_VERSION=2.10 yarn dockerize
-          CKAN_VERSION=2.10 docker compose -f docker-compose.yml -f docker-compose.cypress.yml run cypress /bin/bash -c "npx wait-on http://ckan:5000/api/action/status_show --timeout 120000 && npx cypress install && yarn && NODE_ENV=test npx cypress run --spec cypress/integration/${{ matrix.test-files }}"
+          CKAN_VERSION=2.11 yarn install
+          CKAN_VERSION=2.11 yarn build
+          CKAN_VERSION=2.11 yarn dockerize
+          CKAN_VERSION=2.11 docker compose -f docker-compose.yml -f docker-compose.cypress.yml run cypress /bin/bash -c "npx wait-on http://ckan:5000/api/action/status_show --timeout 120000 && npx cypress install && yarn && NODE_ENV=test npx cypress run --spec cypress/integration/${{ matrix.test-files }}"
       - name: cypress-artifacs
         uses: actions/upload-artifact@v4
         if: failure()

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-ARG CKAN_VERSION=2.10
-FROM openknowledge/ckan-dev:${CKAN_VERSION}
+ARG CKAN_VERSION=2.11
+FROM ckan/ckan-dev:${CKAN_VERSION}
 ARG CKAN_VERSION
 
-RUN apk add swig 
+USER root
+
+RUN apt install swig -y
 RUN pip install --upgrade pip
 
 COPY . ${APP_DIR}/

--- a/cypress.json
+++ b/cypress.json
@@ -2,5 +2,5 @@
   "baseUrl": "http://ckan:5000",
   "chromeWebSecurity": false,
   "videoCompression": false,
-  "requestTimeout": 15000
+  "requestTimeout": 20000
 }

--- a/cypress/integration/additional-metadata.spec.js
+++ b/cypress/integration/additional-metadata.spec.js
@@ -4,6 +4,7 @@ const chance = new Chance();
 describe('Additional Metadata Page', () => {
   before(() => {
     cy.login();
+    cy.create_token();
     cy.deleteDataset('aaaaa');
     cy.deleteDataset('bbbbb');
     cy.deleteDataset('ccccc');
@@ -24,6 +25,7 @@ describe('Additional Metadata Page', () => {
     cy.deleteDataset('ccccc');
     cy.deleteDataset('ddddd');
     cy.deleteOrg('test-organization');
+    cy.revoke_token();
   });
 
   it('Validates and submits Additional Metadata succesfully', () => {

--- a/cypress/integration/additional-metadata.spec.js
+++ b/cypress/integration/additional-metadata.spec.js
@@ -89,6 +89,7 @@ describe('Parent Dataset', () => {
   before(() => {
     cy.logout();
     cy.login();
+    cy.create_token();
     cy.deleteDataset(parentTitle);
     cy.deleteDataset(childTitle);
     cy.deleteOrg('test-organization');

--- a/cypress/integration/edit-dataset.spec.js
+++ b/cypress/integration/edit-dataset.spec.js
@@ -6,6 +6,7 @@ const resourceToBeDeleted = 'resource-to-be-deleted';
 describe('Editing an existing dataset', () => {
   before(() => {
     cy.login();
+    cy.create_token();
     cy.deleteDataset(name);
     cy.deleteOrg('test-organization');
     cy.createOrg('test-organization');
@@ -41,6 +42,7 @@ describe('Editing an existing dataset', () => {
 
   after(() => {
     cy.deleteDataset(name);
+    cy.revoke_token();
   });
 
   it('Loads required metadata values into the form', () => {

--- a/cypress/integration/organization.spec.js
+++ b/cypress/integration/organization.spec.js
@@ -1,6 +1,7 @@
 describe('Organization Page', () => {
   before(() => {
     cy.login();
+    cy.create_token();
     cy.deleteDataset(name);
     cy.deleteOrg('test-organization');
     cy.createOrg('test-organization');
@@ -8,6 +9,7 @@ describe('Organization Page', () => {
 
   after(() => {
     cy.deleteOrg('test-organization');
+    cy.revoke_token();
   });
 
   it('Has only one Add Dataset Button', () => {

--- a/cypress/integration/publishers.spec.js
+++ b/cypress/integration/publishers.spec.js
@@ -1,6 +1,7 @@
 describe('Publishers linked to CKAN org', () => {
   before(() => {
     cy.login();
+    cy.create_token();
     cy.deleteDataset(name);
     cy.deleteOrg('test-organization');
     cy.createOrg('test-organization');
@@ -8,6 +9,7 @@ describe('Publishers linked to CKAN org', () => {
 
   after(() => {
     cy.deleteOrg('test-organization');
+    cy.revoke_token();
   });
 
   it('Has publishers extra in CKAN org metadata', () => {

--- a/cypress/integration/required-metadata.spec.js
+++ b/cypress/integration/required-metadata.spec.js
@@ -27,10 +27,6 @@ describe('Required Metadata Page', () => {
     cy.visit('/dataset/new-metadata');
   });
 
-  after(() => {
-    cy.revoke_token();
-  });
-
   beforeEach(() => {
     cy.logout();
     cy.login();
@@ -145,7 +141,6 @@ describe('Required Metadata Page', () => {
     cy.wait(3000);
     cy.get('select[name=owner_org]').find(':selected').contains('test-organization');
   });
-
   it('Organization is pre-selected in the dropdown if it that organization is the only one', () => {
     const username = 'editor-only-in-one-organization';
     cy.createUser(username);
@@ -155,7 +150,7 @@ describe('Required Metadata Page', () => {
     cy.get('select[name=role]').select('Editor', { force: true });
     cy.get('button[name=submit]').click({ force: true });
     cy.wait(2000);
-
+    cy.revoke_token();
     cy.logout();
     cy.login(username, 'test1234');
 

--- a/cypress/integration/required-metadata.spec.js
+++ b/cypress/integration/required-metadata.spec.js
@@ -15,6 +15,7 @@ describe('DCAT Metadata App', () => {
 describe('Required Metadata Page', () => {
   before(() => {
     cy.login();
+    cy.create_token();
     cy.deleteDataset('daaaa');
     cy.deleteDataset('dbbbb');
     cy.deleteDataset('dcccc');
@@ -24,6 +25,10 @@ describe('Required Metadata Page', () => {
     cy.deleteOrg('test-organization');
     cy.createOrg('test-organization', 'sample organization');
     cy.visit('/dataset/new-metadata');
+  });
+
+  after(() => {
+    cy.revoke_token();
   });
 
   beforeEach(() => {

--- a/cypress/integration/resource-upload.spec.js
+++ b/cypress/integration/resource-upload.spec.js
@@ -370,7 +370,8 @@ describe('Editing resources', () => {
     // Create a resource with  Link to an API
     cy.intercept('/api/3/action/resource_create').as('resourceCreate1');
     cy.get('#resource-option-link-to-api').parent('.form-group').click();
-    cy.get('input[name=resource\\.url]').type('https://www.example.com');
+    cy.wait(1000);
+    cy.get('input[name=resource\\.url]').type('https://example.com/data.csv');
     cy.get('input[name=resource\\.name]').type(resourceWithLinkToApi);
     cy.get('textarea[name=resource\\.description]').type(chance.sentence({ words: 10 }));
     cy.get('button[type=button]').contains('Save and add another resource').click();

--- a/cypress/integration/resource-upload.spec.js
+++ b/cypress/integration/resource-upload.spec.js
@@ -8,6 +8,7 @@ describe('Resource Upload page', () => {
 
   before(() => {
     cy.login();
+    cy.create_token();
     cy.deleteDataset('eeeee');
     cy.deleteOrg('test-organization');
     cy.createOrg('test-organization', 'sample organization');
@@ -33,6 +34,7 @@ describe('Resource Upload page', () => {
       body: { id: longNameResourceDataset },
       failOnStatusCode: false,
     });
+    cy.revoke_token();
   });
 
   it('Links to Data and redirects to dataset page on CKAN', () => {
@@ -185,6 +187,7 @@ describe('Resource Upload page', () => {
 describe('Save draft functionality on Resource Upload page', () => {
   before(() => {
     cy.login();
+    cy.create_token();
     cy.deleteDataset('eeeee');
     cy.deleteOrg('test-organization');
     cy.createOrg('test-organization', 'sample organization');
@@ -197,6 +200,7 @@ describe('Save draft functionality on Resource Upload page', () => {
 
   after(() => {
     cy.deleteDataset('eeeee');
+    cy.revoke_token();
   });
 
   it('Saves draft', () => {
@@ -223,6 +227,7 @@ describe('Editing resources', () => {
 
   before(() => {
     cy.login();
+    cy.create_token();
     cy.deleteDataset(name);
     cy.deleteOrg('test-organization');
     cy.createOrg('test-organization', 'sample organization');
@@ -235,6 +240,10 @@ describe('Editing resources', () => {
 
   afterEach(() => {
     cy.deleteDataset(name);
+  });
+
+  after(() => {
+    cy.revoke_token();
   });
 
   it('Works when editing a resource during dataset creation', () => {

--- a/cypress/integration/user-flow.spec.js
+++ b/cypress/integration/user-flow.spec.js
@@ -2,8 +2,14 @@ import Chance from 'chance';
 const chance = new Chance();
 
 describe('Access to the new metadata app', () => {
+  before(() => {
+    cy.login();
+    cy.create_token();
+  });
+
   after(() => {
     cy.deleteDataset('test-dataset-1');
+    cy.revoke_token();
     cy.logout();
   });
 
@@ -61,9 +67,14 @@ describe('Access to the new metadata app', () => {
 describe('Deleting a dataset', () => {
   before(() => {
     cy.login();
+    cy.create_token();
     cy.deleteDataset('test-dataset-1');
     cy.deleteOrg('test-organization');
     cy.createOrg('test-organization', 'sample organization');
+  });
+
+  after(() => {
+    cy.revoke_token();
   });
 
   afterEach(() => {
@@ -92,6 +103,7 @@ describe('List of organizations on new metadata form', () => {
   before(() => {
     cy.createUser('editor');
     cy.login();
+    // cy.create_token();
     cy.visit('/organization/member_new/test-organization');
     cy.get('input[name=username]').type('editor', { force: true });
     cy.get('select[name=role]').select('Editor', { force: true });
@@ -101,6 +113,7 @@ describe('List of organizations on new metadata form', () => {
 
   after(() => {
     cy.deleteDataset('test-dataset-1');
+    // cy.revoke_token();
     cy.logout();
   });
 
@@ -123,6 +136,7 @@ describe('List of organizations on new metadata form', () => {
 describe('Go back to dashboard page', () => {
   before(() => {
     cy.login();
+    cy.create_token();
     cy.deleteOrg('test-organization');
     cy.createOrg('test-organization', 'sample organization');
   });
@@ -135,6 +149,7 @@ describe('Go back to dashboard page', () => {
   after(() => {
     cy.deleteDataset('fffff');
     cy.deleteDataset('test-dataset-1');
+    cy.revoke_token();
     cy.logout();
   });
 

--- a/cypress/integration/user-flow.spec.js
+++ b/cypress/integration/user-flow.spec.js
@@ -94,7 +94,7 @@ describe('Deleting a dataset', () => {
     cy.requiredMetadata('test-dataset-1');
     cy.visit('/dataset/test-dataset-1');
     cy.get('.btn-danger').click({ force: true });
-    cy.wait(2000);
+    cy.wait(4000);
     cy.contains('Are you sure you want to delete dataset');
   });
 });

--- a/cypress/integration/user-flow.spec.js
+++ b/cypress/integration/user-flow.spec.js
@@ -95,30 +95,29 @@ describe('Deleting a dataset', () => {
     cy.visit('/dataset/test-dataset-1');
     cy.get('.btn-danger').click({ force: true });
     cy.wait(2000);
-    cy.contains('Are you sure you want to delete dataset -');
+    cy.contains('Are you sure you want to delete dataset');
   });
 });
 
 describe('List of organizations on new metadata form', () => {
   before(() => {
-    cy.createUser('editor');
     cy.login();
-    // cy.create_token();
+    cy.create_token();
+    cy.createUser('editor');
     cy.visit('/organization/member_new/test-organization');
     cy.get('input[name=username]').type('editor', { force: true });
     cy.get('select[name=role]').select('Editor', { force: true });
     cy.get('button[name=submit]').click({ force: true });
     cy.wait(2000);
+    cy.logout();
   });
 
   after(() => {
     cy.deleteDataset('test-dataset-1');
-    // cy.revoke_token();
     cy.logout();
   });
 
   it('Displays expected organizations for the editor role', () => {
-    cy.logout();
     cy.visit('/user/login');
     cy.get('input[name=login]').type('editor');
     cy.get('input[name=password]').type('test1234');

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -2,46 +2,133 @@ import 'chance';
 import 'cypress-file-upload';
 
 Cypress.Commands.add('login', (username = 'admin', password = 'password') => {
-  cy.clearCookies();
+  /**
+   * Method to fill and submit the CKAN Login form
+   * :PARAM userName String: user name of that will be attempting to login
+   * :PARAM password String: password for the user logging in
+   * :RETURN null:
+   */
+  cy.logout();
   cy.visit('/user/login');
-  cy.get('input[name=login]').type(username);
-  cy.get('input[name=password]').type(password);
-  cy.get('.form-actions > .btn').click({ force: true });
-  cy.wait(2000);
+
+  // set the username and password for the defaults
+  Cypress.env('USER', username);
+  Cypress.env('USER_PASSWORD', password);
+
+  // Hide flask debug toolbar
+  cy.get('#flDebugHideToolBarButton').click();
+
+  cy.get('#field-login').type(username);
+  cy.get('#field-password').type(password);
+  cy.get('.btn-primary').click();
 });
 
 Cypress.Commands.add('logout', () => {
   cy.clearCookies();
 });
 
-Cypress.Commands.add('createOrg', (orgName, orgDesc) => {
-  /**
-   *  * Method to create organization via CKAN API
-   *   * :PARAM orgName String: Name of the organization being created
-   *   * :PARAM orgDesc String: Description of the organization being created
-   *   * :PARAM orgTest Boolean: Control value to determine if to use UI to create organization
-   *   *  for testing or to visit the organization creation page
-   *   * :RETURN null:
-   *   */
+Cypress.Commands.add('create_token', (tokenName) => {
+  // return if token already exists
+  const token_data = Cypress.env('token_data');
 
-  cy.request({
-    url: '/api/action/organization_create',
-    method: 'POST',
-    body: {
-      description: orgDesc,
-      title: orgName,
-      approval_status: 'approved',
-      state: 'active',
-      name: orgName,
-      extras: [
-        {
-          key: 'publisher',
-          value: `[["${orgName}", "${orgName}", "top level publisher"], ["${orgName}", "${orgName}", "top level publisher", "first level publisher", "second level publisher"]]`,
-        },
-      ],
-    },
+  if (token_data) {
+    cy.log('Token already exists. skipping token creation.');
+    cy.log(token_data);
+    return;
+  }
+
+  cy.login();
+
+  if (!tokenName) {
+    tokenName = 'cypress token';
+  }
+
+  const userName = Cypress.env('USER');
+  // create an API token named 'cypress token'
+  cy.visit('/user/' + userName + '/api-tokens');
+
+  cy.get('body').then(($body) => {
+    cy.get('#name').type('cypress token');
+    cy.get('button[value="create"]').click();
+    // find the token in <code> tag and save it for later use
+    // find the token id (jti) somewhere in the form
+    cy.get('div.alert-success code')
+      .invoke('text')
+      .then((text1) => {
+        cy.get('form[action^="/user/' + userName + '/api-tokens/"]')
+          .invoke('attr', 'action')
+          .then((text2) => {
+            const jti = text2.split('/')[4];
+            Cypress.env('token_data', { api_token: text1, jti: jti });
+          });
+      });
+    cy.log('cypress token created.');
   });
 });
+
+Cypress.Commands.add('revoke_token', (tokenName) => {
+  const token_data = Cypress.env('token_data');
+
+  if (!token_data) {
+    return;
+  }
+
+  if (!tokenName) {
+    tokenName = 'cypress token';
+  }
+  cy.log('Revoking cypress token.......');
+  cy.request({
+    url: '/api/3/action/api_token_revoke',
+    method: 'POST',
+    withCredentials: false,
+    headers: {
+      Authorization: token_data.api_token,
+      'Content-Type': 'application/json',
+    },
+    body: { token: token_data.api_token },
+  });
+});
+
+Cypress.Commands.add(
+  'createOrg',
+  (orgName = 'test-organization', orgDesc = 'sample organization') => {
+    /**
+     * Method to create organization via CKAN API
+     * :PARAM orgName String: Name of the organization being created
+     * :PARAM orgDesc String: Description of the organization being created
+     * :PARAM orgTest Boolean: Control value to determine if to use UI to create organization
+     *      for testing or to visit the organization creation page
+     * :RETURN null:
+     */
+    const token_data = Cypress.env('token_data');
+
+    let request_obj = {
+      url: '/api/3/action/organization_create',
+      method: 'POST',
+      headers: {
+        Authorization: token_data.api_token,
+        'Content-Type': 'application/json',
+      },
+      // avoids sending cookie
+      withCredentials: false,
+      body: {
+        name: orgName,
+        title: orgName,
+        description: orgDesc,
+        approval_status: 'approved',
+        state: 'active',
+        extras: [
+          {
+            key: 'publisher',
+            value: `[["${orgName}", "${orgName}", "top level publisher"], ["${orgName}", "${orgName}", "top level publisher", "first level publisher", "second level publisher"]]`,
+          },
+        ],
+      },
+    };
+
+    cy.request(request_obj);
+  }
+);
 
 Cypress.Commands.add('deleteOrg', (orgName) => {
   /**
@@ -49,20 +136,33 @@ Cypress.Commands.add('deleteOrg', (orgName) => {
    * :PARAM orgName String: Name of the organization to purge from the current state
    * :RETURN null:
    */
+  const token_data = Cypress.env('token_data');
+
   cy.request({
     url: '/api/action/organization_delete',
     method: 'POST',
     failOnStatusCode: false,
+    headers: {
+      Authorization: token_data.api_token,
+      'Content-Type': 'application/json',
+    },
+    withCredentials: false,
     body: {
-      id: orgName,
+      id: orgName ? orgName : 'test-organization',
     },
   });
+
   cy.request({
     url: '/api/action/organization_purge',
     method: 'POST',
     failOnStatusCode: false,
+    headers: {
+      Authorization: token_data.api_token,
+      'Content-Type': 'application/json',
+    },
+    withCredentials: false,
     body: {
-      id: orgName,
+      id: orgName ? orgName : 'test-organization',
     },
   });
 });
@@ -73,11 +173,20 @@ Cypress.Commands.add('deleteDataset', (datasetName) => {
    ** :PARAM datasetName String: Name of the dataset to purge from the current state
    ** :RETURN null:
    **/
+
+  const token_data = Cypress.env('token_data');
   cy.request({
     url: '/api/action/dataset_purge',
     method: 'POST',
     failOnStatusCode: false,
-    body: { id: datasetName },
+    withCredentials: false,
+    headers: {
+      Authorization: token_data.api_token,
+      'Content-Type': 'application/json',
+    },
+    body: {
+      id: datasetName,
+    },
   });
 });
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -24,6 +24,7 @@ Cypress.Commands.add('login', (username = 'admin', password = 'password') => {
 });
 
 Cypress.Commands.add('logout', () => {
+  cy.log('Logging out - clearing cookies');
   cy.clearCookies();
 });
 
@@ -96,8 +97,6 @@ Cypress.Commands.add(
      * Method to create organization via CKAN API
      * :PARAM orgName String: Name of the organization being created
      * :PARAM orgDesc String: Description of the organization being created
-     * :PARAM orgTest Boolean: Control value to determine if to use UI to create organization
-     *      for testing or to visit the organization creation page
      * :RETURN null:
      */
     const token_data = Cypress.env('token_data');
@@ -120,13 +119,23 @@ Cypress.Commands.add(
         extras: [
           {
             key: 'publisher',
-            value: `[["${orgName}", "${orgName}", "top level publisher"], ["${orgName}", "${orgName}", "top level publisher", "first level publisher", "second level publisher"]]`,
+            value: JSON.stringify([
+              [orgName, orgName, 'top level publisher'],
+              [
+                orgName,
+                orgName,
+                'top level publisher',
+                'first level publisher',
+                'second level publisher',
+              ],
+            ]),
           },
         ],
       },
     };
 
     cy.request(request_obj);
+    cy.wait(2000);
   }
 );
 
@@ -176,7 +185,7 @@ Cypress.Commands.add('deleteDataset', (datasetName) => {
 
   const token_data = Cypress.env('token_data');
   cy.request({
-    url: '/api/action/dataset_purge',
+    url: '/api/3/action/dataset_purge',
     method: 'POST',
     failOnStatusCode: false,
     withCredentials: false,
@@ -191,7 +200,7 @@ Cypress.Commands.add('deleteDataset', (datasetName) => {
 });
 
 Cypress.Commands.add('createUser', (username) => {
-  cy.clearCookies();
+  // creates a user, must be called while logged in!
   cy.visit('/user/register');
   const name = username || chance.name({ length: 5 });
   cy.get('input[name=name]').type(name);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       CKAN_SOLR_URL: http://solr:8983/solr/ckan
       CKAN_REDIS_URL: redis://redis:6379/1
       CKAN_DATAPUSHER_URL: http://localhost:8080/ # datapusher is not really enabled
-      CKAN__PLUGINS: dcat_usmetadata usmetadata
+      CKAN__PLUGINS: dcat_usmetadata usmetadata tracking
       PYTHONDONTWRITEBYTECODE: 1
     # command: /bin/bash -c "while ! nc -zv db 5432; do echo \"CKAN** Waiting for DB\"; sleep 3; done; /srv/app/start_ckan_development.sh"
     depends_on:

--- a/makefile
+++ b/makefile
@@ -8,7 +8,15 @@ up:
 	CKAN_VERSION=$(CKAN_VERSION) docker compose -f $(COMPOSE_FILE) up
 
 down:
-	docker compose down
+	CKAN_VERSION=$(CKAN_VERSION) docker compose down
+
+test_e2e:
+	# CKAN_VERSION=$(CKAN_VERSION) docker compose -f docker-compose.yml -f docker-compose.cypress.yml run cypress /bin/bash -c "npx wait-on http://ckan:5000/api/action/status_show --timeout 120000 && npx cypress install && yarn && NODE_ENV=test npx cypress run --spec cypress/integration/required-metadata.spec.js"
+	CKAN_VERSION=$(CKAN_VERSION) docker compose -f docker-compose.yml -f docker-compose.cypress.yml run cypress /bin/bash -c "npx wait-on http://ckan:5000/api/action/status_show --timeout 120000 && npx cypress install && yarn && NODE_ENV=test npx cypress run"
+
+test_e2e_interactive:
+	CKAN_VERSION=$(CKAN_VERSION) docker compose -f docker-compose.yml up -d && yarn && NODE_ENV=test npx cypress open
+	
 
 .DEFAULT_GOAL := help
 .PHONY: build up

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-CKAN_VERSION ?= 2.10
+CKAN_VERSION ?= 2.11
 COMPOSE_FILE ?= docker-compose.yml
 
 build: 


### PR DESCRIPTION
- Upgrades the Docker CKAN version to 2.11
- Updates the tests to function more reliably
- Updates the tests to account for the required API Key for API requests by Cypress