### PR TITLE
Bumps The Version Number to 0.6.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # http://packaging.python.org/en/latest/tutorial.html#version
-    version="0.6.0",
+    version="0.6.2",
     description="""DCAT USMetadata Form App for CKAN""",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Reference to PR: https://github.com/GSA/ckanext-dcat_usmetadata/pull/337

This PR is meant to bump the version number so that we can publish the changes introduced in the above PR to pypi.