### PR TITLE
5433: Inventory dataset form: can't change resource type

### DIFF
--- a/metadata-app/src/api/index.js
+++ b/metadata-app/src/api/index.js
@@ -92,10 +92,11 @@ const serializeResource = (resource) => {
   // delete serializedResource.resource_type;
 
   if (serializedResource.urlType) {
-    if (
-      serializedResource.urlType === RESOURCE_URL_TYPES.LINK_TO_API ||
-      serializedResource.urlType === RESOURCE_URL_TYPES.ACCESS_URL
-    ) {
+    if (serializedResource.urlType === RESOURCE_URL_TYPES.LINK_TO_API) {
+      serializedResource.resource_type = 'api';
+      serializedResource.url_type = 'url';
+    }
+    if (serializedResource.urlType === RESOURCE_URL_TYPES.ACCESS_URL) {
       serializedResource.resource_type = 'accessurl';
       serializedResource.url_type = 'url';
     }
@@ -115,11 +116,11 @@ const serializeResource = (resource) => {
 const deserializeResource = (resource) => {
   const deserializedResource = clone(resource);
   deserializedResource.urlType = resource.url_type;
+  if (deserializedResource.resource_type === 'api') {
+    deserializedResource.urlType = RESOURCE_URL_TYPES.LINK_TO_API;
+  }
   if (deserializedResource.resource_type === 'accessurl') {
     deserializedResource.urlType = RESOURCE_URL_TYPES.ACCESS_URL;
-    if (deserializedResource.format === 'API') {
-      deserializedResource.urlType = RESOURCE_URL_TYPES.LINK_TO_API;
-    }
   }
   return deserializedResource;
 };

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # http://packaging.python.org/en/latest/tutorial.html#version
-    version="0.6.3",
+    version="0.6.4",
     description="""DCAT USMetadata Form App for CKAN""",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Related to [Issue #5433](https://github.com/GSA/data.gov/issues/5433)

This PR is to fix a bug where editing the resource type for a dataset doesn't persist when that resource type changes. 